### PR TITLE
Added configurable scriptErrorsSuppressed parameter to GetWebLoginClientContext method.

### DIFF
--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -281,8 +281,9 @@ namespace OfficeDevPnP.Core
         /// </summary>
         /// <param name="siteUrl">Site for which the ClientContext object will be instantiated</param>
         /// <param name="icon">Optional icon to use for the popup form</param>
+        /// <param name="scriptErrorsSuppressed">Optional parameter to set WebBrowser.ScriptErrorsSuppressed value in the popup form</param>
         /// <returns>ClientContext to be used by CSOM code</returns>
-        public ClientContext GetWebLoginClientContext(string siteUrl, System.Drawing.Icon icon = null)
+        public ClientContext GetWebLoginClientContext(string siteUrl, System.Drawing.Icon icon = null, bool scriptErrorsSuppressed = true)
         {
             var authCookiesContainer = new CookieContainer();
             var siteUri = new Uri(siteUrl);
@@ -296,7 +297,7 @@ namespace OfficeDevPnP.Core
                 }
                 var browser = new System.Windows.Forms.WebBrowser
                 {
-                    ScriptErrorsSuppressed = true,
+                    ScriptErrorsSuppressed = scriptErrorsSuppressed,
                     Dock = DockStyle.Fill
                 };
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | none

#### What's in this Pull Request?

Added optional configurable scriptErrorsSuppressed parameter to GetWebLoginClientContext method. The default value is set to true to make sure that the signature does not change and existing code works without changes.

This fix is needed because when WebBrowser.ScriptErrorsSuppressed is set to true, all client dialogs initiated by browser control are being blocked. This makes debugging GetWebLoginClientContext method impossible. For example, if the client has configured different security zones for *.sharepoint.com and login.microsoftonline.com in the browser, during authentication redirects WebBrowser control will show security warning like "The current web page is trying to open a site on your intranet. Do you want to allow this?". With ScriptErrorsSuppressed set to true this warning will get blocked, and after authentication the user will see an empty form doing nothing.
