### PR TITLE
Using additional headers for HTTP requests

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/HttpRequestHeadersExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/HttpRequestHeadersExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Net.Http.Headers;
+
+namespace OfficeDevPnP.Core.Extensions
+{
+    public static class HttpRequestHeadersExtensions
+    {
+        public static void AddDictionary(this HttpRequestHeaders header, Dictionary<string, string> additionalHeaders)
+        {
+            if (header == null || additionalHeaders == null)
+            {
+                return;
+            }
+            foreach (var additionalHeader in additionalHeaders)
+            {
+                header.Add(additionalHeader.Key, additionalHeader.Value);
+            }
+        }
+    }
+}

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -509,6 +509,7 @@
     <Compile Include="Extensions\ExternalSharingExtensions.cs" />
     <Compile Include="Extensions\FieldAndContentTypeExtensions.cs" />
     <Compile Include="Extensions\FileFolderExtensions.cs" />
+    <Compile Include="Extensions\HttpRequestHeadersExtensions.cs" />
     <Compile Include="Extensions\InformationManagementExtensions.cs" />
     <Compile Include="Extensions\InternalClientContextExtensions.cs" />
     <Compile Include="Extensions\ListExtensions.cs" />

--- a/Core/OfficeDevPnP.Core/Utilities/RESTUtilities.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/RESTUtilities.cs
@@ -53,11 +53,12 @@ namespace OfficeDevPnP.Core.Utilities
         /// </summary>
         /// <param name="web">The current web to execute the request against</param>
         /// <param name="endpoint">The full endpoint url, exluding the URL of the web, e.g. /_api/web/lists</param>
+        /// <param name="additionalHeaders">Additional headers that should be included in the web request</param>
         /// <returns></returns>
-        internal static async Task<string> ExecuteGet(this Web web, string endpoint)
+        internal static async Task<string> ExecuteGet(this Web web, string endpoint, Dictionary<string, string> additionalHeaders = null)
         {
             string returnObject = null;
-            var accessToken = web.Context.GetAccessToken();
+            var accessToken = web.Context.GetAccessToken(additionalHeaders);
 
             using (var handler = new HttpClientHandler())
             {
@@ -87,7 +88,7 @@ namespace OfficeDevPnP.Core.Utilities
                             handler.Credentials = networkCredential;
                         }
                     }
-                    request.Headers.Add("X-RequestDigest", await (web.Context as ClientContext).GetRequestDigest());
+                    request.Headers.Add("X-RequestDigest", await (web.Context as ClientContext).GetRequestDigest(additionalHeaders));
 
                     // Perform actual post operation
                     HttpResponseMessage response = await httpClient.SendAsync(request, new System.Threading.CancellationToken());
@@ -117,10 +118,10 @@ namespace OfficeDevPnP.Core.Utilities
             return await Task.Run(() => returnObject);
         }
 
-        internal static async Task<string> ExecutePost(this Web web, string endpoint, string payload)
+        internal static async Task<string> ExecutePost(this Web web, string endpoint, string payload, Dictionary<string, string> additionalHeaders = null)
         {
             string returnObject = null;
-            var accessToken = web.Context.GetAccessToken();
+            var accessToken = web.Context.GetAccessToken(additionalHeaders);
 
             using (var handler = new HttpClientHandler())
             {
@@ -150,7 +151,7 @@ namespace OfficeDevPnP.Core.Utilities
                             handler.Credentials = networkCredential;
                         }
                     }
-                    request.Headers.Add("X-RequestDigest", await (web.Context as ClientContext).GetRequestDigest());
+                    request.Headers.Add("X-RequestDigest", await (web.Context as ClientContext).GetRequestDigest(additionalHeaders));
 
                     if (!string.IsNullOrEmpty(payload))
                     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes https://github.com/SharePoint/PnP-PowerShell/issues/808, dependency of PR https://github.com/SharePoint/PnP-PowerShell/pull/2068 

#### What's in this Pull Request?

In scenarios where an on premises SharePoint server uses Windows Authentication as well as a different authorization provider (e.g. Azure AD), it is not possible to use an Active Directory login to authenticate against SharePoint. As discussed in issue https://github.com/SharePoint/PnP-PowerShell/issues/808, a workaround is to deactivate forms based authentication by passing the `X-FORMS_BASED_AUTH_ACCEPTED` with the value `f` in the header of the request. The first iteration of PR https://github.com/SharePoint/PnP-PowerShell/pull/2068 did that solely within the scope of the PowerShell CmdLets, however this only works with commands that are based on CSOM. If the newer REST API calls are used (in our case, the ALM CmdLets), new HttpClients instances are used that do not inherit the settings (and therefore headers) of the traditional calls. In these instances, the header has to be set again.
This PR implements a generic solution for this issue that uses an optional `Dictionary` that contains additional header that should be added to Web Requests. The related PR https://github.com/SharePoint/PnP-PowerShell/pull/2068 in the PnP-PowerShell project adds the necessary configuration for the `X-FORMS_BASED_AUTH_ACCEPTED` header. 
This generic solution was chosen, because there is currently no approach on how to pass configuration values from the PowerShell command line to fundamental operations in the Sites-Core project. Furthermore, if additional headers might be necessary for other scenarios, these can be added with ease.