### PR TITLE
Feature: Added support to delete modern sites

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
@@ -817,6 +817,18 @@ namespace Microsoft.SharePoint.Client
 
             return await SiteCollection.TeamifySiteAsync(clientContext);
         }
+
+        /// <summary>
+        /// Deletes a Communication site or a group-less Modern team site
+        /// </summary>
+        /// <param name="clientContext"></param>
+        /// <returns></returns>
+        public static async Task<bool> DeleteSiteAsync(this ClientContext clientContext)
+        {
+            await new SynchronizationContextRemover();
+
+            return await SiteCollection.DeleteSiteAsync(clientContext);
+        }
 #endif
     }
 }

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -633,7 +633,7 @@ namespace OfficeDevPnP.Core.Sites
         {
             string responseString = null;
 
-            context.Site.EnsureProperties(s => s.GroupId);
+            context.Site.EnsureProperty(s => s.GroupId);
 
             if (context.Web.IsSubSite())
             {
@@ -668,7 +668,7 @@ namespace OfficeDevPnP.Core.Sites
 
             if (webTemplateId == "SITEPAGEPUBLISHING#0" || webTemplateId == "STS#3")
             {
-                context.Site.EnsureProperties(s => s.Id);
+                context.Site.EnsureProperty(s => s.Id);
 
                 var result = await context.Web.ExecutePost("/_api/SPSiteManager/delete", $@" {{ ""siteId"": ""{context.Site.Id.ToString()}"" }}");
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes NA

#### What's in this Pull Request?

This PR adds support to delete modern communication or modern team site(groupless as well as backed by O365 group) 
It is based on [create modern SharePoint site](https://docs.microsoft.com/en-us/sharepoint/dev/apis/site-creation-rest) guidance.