### PR TITLE
Fix for ObjectTermGroups deploying terms with tokens multiple times

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/TermGroupHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/TermGroupHelper.cs
@@ -165,7 +165,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                             var term = terms.FirstOrDefault(t => t.Id == modelTerm.Id);
                             if (term == null)
                             {
-                                var normalizedTermName = TaxonomyItem.NormalizeName(context, modelTerm.Name);
+                                var normalizedTermName = TaxonomyItem.NormalizeName(context, parser.ParseString(modelTerm.Name));
                                 context.ExecuteQueryRetry();
 
                                 term = terms.FirstOrDefault(t => t.Name == normalizedTermName.Value);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/TermGroupHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/TermGroupHelper.cs
@@ -171,7 +171,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                                 term = terms.FirstOrDefault(t => t.Name == normalizedTermName.Value);
                                 if (term == null)
                                 {
-                                    var returnTuple = CreateTerm<TermSet>(context, modelTerm, set, termStore, parser, scope);
+                                    var returnTuple = CreateTerm(context, modelTerm, set, termStore, parser, scope);
                                     if (returnTuple != null)
                                     {
                                         modelTerm.Id = returnTuple.Item1;
@@ -198,7 +198,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                         }
                         else
                         {
-                            var returnTuple = CreateTerm<TermSet>(context, modelTerm, set, termStore, parser, scope);
+                            var returnTuple = CreateTerm(context, modelTerm, set, termStore, parser, scope);
                             if (returnTuple != null)
                             {
                                 modelTerm.Id = returnTuple.Item1;
@@ -209,7 +209,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                     }
                     else
                     {
-                        var returnTuple = CreateTerm<TermSet>(context, modelTerm, set, termStore, parser, scope);
+                        var returnTuple = CreateTerm(context, modelTerm, set, termStore, parser, scope);
                         if (returnTuple != null)
                         {
                             modelTerm.Id = returnTuple.Item1;
@@ -264,8 +264,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
             return existingTerm.ServerObjectIsNull == true;
         }
 
-        internal static Tuple<Guid, TokenParser, List<ReusedTerm>> CreateTerm<T>(ClientContext context, Model.Term modelTerm, TaxonomyItem parent,
-           TermStore termStore, TokenParser parser, PnPMonitoredScope scope) where T : TaxonomyItem
+        internal static Tuple<Guid, TokenParser, List<ReusedTerm>> CreateTerm(ClientContext context, Model.Term modelTerm, TaxonomyItem parent,
+           TermStore termStore, TokenParser parser, PnPMonitoredScope scope)
         {
 
             var reusedTerms = new List<ReusedTerm>();
@@ -278,7 +278,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                     Parent = parent,
                     TermStore = termStore
                 });
-                return Tuple.Create(modelTerm.Id, parser, reusedTerms); ;
+                return Tuple.Create(modelTerm.Id, parser, reusedTerms);
             }
 
             // Create new term
@@ -407,7 +407,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                             termTerm = termTerms.FirstOrDefault(t => t.Name == modelTermTerm.Name);
                             if (termTerm == null)
                             {
-                                var returnTuple = CreateTerm<Term>(context, modelTermTerm, term, termStore, parser, scope);
+                                var returnTuple = CreateTerm(context, modelTermTerm, term, termStore, parser, scope);
                                 if (returnTuple != null)
                                 {
                                     modelTermTerm.Id = returnTuple.Item1;
@@ -426,7 +426,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                     }
                     else
                     {
-                        var returnTuple = CreateTerm<Term>(context, modelTermTerm, term, termStore, parser, scope);
+                        var returnTuple = CreateTerm(context, modelTermTerm, term, termStore, parser, scope);
                         if (returnTuple != null)
                         {
                             modelTermTerm.Id = returnTuple.Item1;
@@ -575,7 +575,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                             term = terms.FirstOrDefault(t => t.Name == normalizedTermName.Value);
                             if (term == null)
                             {
-                                var returnTuple = CreateTerm<TermSet>(context, childTerm, parentTerm, termStore, parser, scope);
+                                var returnTuple = CreateTerm(context, childTerm, parentTerm, termStore, parser, scope);
                                 if (returnTuple != null)
                                 {
                                     childTerm.Id = returnTuple.Item1;
@@ -599,7 +599,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                     }
                     else
                     {
-                        var returnTuple = CreateTerm<TermSet>(context, childTerm, parentTerm, termStore, parser, scope);
+                        var returnTuple = CreateTerm(context, childTerm, parentTerm, termStore, parser, scope);
                         if (returnTuple != null)
                         {
                             childTerm.Id = returnTuple.Item1;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  |

#### What's in this Pull Request?

This PR fixes an issue with **ObjectTermGroups** caused by **TermGroupHelper** when deploying terms with tokens multiple times to a term store.

Previously **TermGroupHelper** has not used the **TokenParser** to replace existing tokens in a term name when checking for an existing term, which caused the creation of a new term and a **ServerException** (due to an already existing ID).