### PR TITLE
Feature : added support for O365 Group settings

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHierarchyTenant.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHierarchyTenant.cs
@@ -41,6 +41,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     parser = TenantHelper.ProcessSiteDesigns(tenant, hierarchy.Tenant, parser, scope, MessagesDelegate);
                     parser = TenantHelper.ProcessStorageEntities(tenant, hierarchy.Tenant, parser, scope, applyingInformation, MessagesDelegate);
                     parser = TenantHelper.ProcessThemes(tenant, hierarchy.Tenant, parser, scope, MessagesDelegate);
+                    parser = TenantHelper.ProcessO365GroupSettings(tenant, hierarchy.Tenant, parser, scope, MessagesDelegate);
                     // So far we do not provision CDN settings
                     // It will come in the near future
                     // NOOP on CDN

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTenant.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTenant.cs
@@ -49,6 +49,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         parser = TenantHelper.ProcessSiteDesigns(tenant, template.Tenant, parser, scope, MessagesDelegate);
                         parser = TenantHelper.ProcessStorageEntities(tenant, template.Tenant, parser, scope, applyingInformation, MessagesDelegate);
                         parser = TenantHelper.ProcessThemes(tenant, template.Tenant, parser, scope, MessagesDelegate);
+                        parser = TenantHelper.ProcessO365GroupSettings(tenant, template.Tenant, parser, scope, MessagesDelegate);
                     }
                 }
             }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/TenantHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/TenantHelper.cs
@@ -5,9 +5,12 @@ using Microsoft.SharePoint.Client;
 using Newtonsoft.Json;
 using OfficeDevPnP.Core.ALM;
 using OfficeDevPnP.Core.Diagnostics;
+using OfficeDevPnP.Core.Framework.Graph;
+using OfficeDevPnP.Core.Framework.Graph.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.Connectors;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions;
+using OfficeDevPnP.Core.Utilities.Graph;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -650,6 +653,143 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                 returnDict.Add((SPOTenantCdnPolicyType)Enum.Parse(typeof(SPOTenantCdnPolicyType), entryArray[0]), entryArray[1]);
             }
             return returnDict;
+        }
+
+        public static TokenParser ProcessO365GroupSettings(Tenant tenant, ProvisioningTenant provisioningTenant, TokenParser parser, PnPMonitoredScope scope, ProvisioningMessagesDelegate messagesDelegate)
+        {
+            if (provisioningTenant.Office365GroupsSettings != null && provisioningTenant.Office365GroupsSettings.Properties.Any())
+            {
+                messagesDelegate?.Invoke("Processing Office 365 Group Settings", ProvisioningMessageType.Progress);
+                bool siteClassificationSettingsExists = false;
+                if (PnPProvisioningContext.Current != null)
+                {
+                    string accessToken = string.Empty;
+                    try
+                    {
+                        // Get a fresh Access Token for every request
+                        accessToken = PnPProvisioningContext.Current.AcquireToken(GraphHelper.MicrosoftGraphBaseURI, "Directory.ReadWrite.All");
+
+                        if (accessToken != null)
+                        {
+                            try
+                            {
+                                var siteClassificationSettings = tenant.GetSiteClassificationsSettings(accessToken);
+                                siteClassificationSettingsExists = true;
+                            }
+                            catch (Exception ex)
+                            {
+                                // Tenant classification doesn't exist, just swallow the exception.
+                            }
+
+                            if (siteClassificationSettingsExists)
+                            {
+                                // Tenant classification exists, update the necessary values for Group Settings.
+                                try
+                                {
+                                    string directorySettingTemplatesUrl = $"{GraphHttpClient.MicrosoftGraphV1BaseUri}groupSettings";
+                                    var directorySettingTemplatesJson = GraphHttpClient.MakeGetRequestForString(directorySettingTemplatesUrl, accessToken);
+                                    var directorySettingTemplates = JsonConvert.DeserializeObject<DirectorySettingTemplates>(directorySettingTemplatesJson);
+
+                                    // Retrieve the setinngs for "Group.Unified"
+                                    var unifiedGroupSetting = directorySettingTemplates.Templates.FirstOrDefault(t => t.DisplayName == "Group.Unified");
+
+                                    if (unifiedGroupSetting != null)
+                                    {
+                                        var props = provisioningTenant.Office365GroupsSettings.Properties;
+                                        foreach (var v in unifiedGroupSetting.SettingValues)
+                                        {
+                                            var item = props.Where(p => p.Key == v.Name).FirstOrDefault();
+                                            if (!string.IsNullOrEmpty(item.Key))
+                                            {
+                                                v.Value = parser.ParseString(item.Value);
+                                            }
+                                        }
+
+                                        string updateDirectorySettingUrl = $"{GraphHttpClient.MicrosoftGraphV1BaseUri}groupSettings/{unifiedGroupSetting.Id}";
+                                        var updateDirectorySettingResult = GraphHttpClient.MakePatchRequestForString(
+                                            updateDirectorySettingUrl,
+                                            content: new
+                                            {
+                                                templateId = unifiedGroupSetting.Id,
+                                                values = from v in unifiedGroupSetting.SettingValues select new { name = v.Name, value = v.Value },
+                                            },
+                                            contentType: "application/json",
+                                            accessToken: accessToken);
+
+                                    }
+                                    else
+                                    {
+                                        throw new ApplicationException("Missing DirectorySettingTemplate for \"Group.Unified\"");
+                                    }
+                                }
+                                catch (Exception ex)
+                                {
+                                    scope.LogError($"Error occurred processing O365 Group settings ${ex.Message}");
+                                }
+                            }
+                            else
+                            {
+                                // Tenant classification doesn't exist, create the necessary template for Group Settings.
+
+                                try
+                                {
+                                    string directorySettingTemplatesUrl = $"{GraphHttpClient.MicrosoftGraphV1BaseUri}groupSettingTemplates";
+                                    var directorySettingTemplatesJson = GraphHttpClient.MakeGetRequestForString(directorySettingTemplatesUrl, accessToken);
+                                    var directorySettingTemplates = JsonConvert.DeserializeObject<DirectorySettingTemplates>(directorySettingTemplatesJson);
+
+                                    // Retrieve the setinngs for "Group.Unified"
+                                    var unifiedGroupSetting = directorySettingTemplates.Templates.FirstOrDefault(t => t.DisplayName == "Group.Unified");
+
+                                    if (unifiedGroupSetting != null)
+                                    {
+                                        var props = provisioningTenant.Office365GroupsSettings.Properties;
+                                        foreach (var v in unifiedGroupSetting.SettingValues)
+                                        {
+                                            var item = props.Where(p => p.Key == v.Name).FirstOrDefault();
+                                            if (!string.IsNullOrEmpty(item.Key))
+                                            {
+                                                v.Value = parser.ParseString(item.Value);
+                                            }
+                                            else
+                                            {
+                                                // Set default value because null is not supported
+                                                // It only accepts entire collection and not individual properties
+                                                v.Value = v.DefaultValue;
+                                            }
+                                        }
+
+                                        string updateDirectorySettingUrl = $"{GraphHttpClient.MicrosoftGraphV1BaseUri}groupSettings";
+                                        var updateDirectorySettingResult = GraphHttpClient.MakePostRequestForString(
+                                            updateDirectorySettingUrl,
+                                            content: new
+                                            {
+                                                templateId = unifiedGroupSetting.Id,
+                                                values = from v in unifiedGroupSetting.SettingValues select new { name = v.Name, value = v.Value },
+                                            },
+                                            contentType: "application/json",
+                                            accessToken: accessToken);
+
+                                    }
+                                    else
+                                    {
+                                        throw new ApplicationException("Missing DirectorySettingTemplate for \"Group.Unified\"");
+                                    }
+                                }
+                                catch (Exception ex)
+                                {
+                                    scope.LogError($"Error occurred processing O365 Group settings ${ex.Message}");
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        scope.LogError($"Error occurred processing O365 Group settings ${ex.Message}");
+                    }
+
+                }
+            }
+            return parser;
         }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

This PR adds support for provisioning/updating O365 Group settings via the engine. It uses the PnPProvisoningContext helper methods and the necessary Graph endpoints to achieve the same.