### PR TITLE
Fix for ObjectListInstanceDataRows when deploying data rows with security information

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -131,7 +131,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                         IsNewItem = true;
                                     }
 
-                                    ListItemUtilities.UpdateListItem(listitem, parser, dataRow.Values, ListItemUtilities.ListItemUpdateType.UpdateOverwriteVersion, IsNewItem);
+                                    ListItemUtilities.ListItemUpdateType updateMode = IsNewItem ? ListItemUtilities.ListItemUpdateType.Update : ListItemUtilities.ListItemUpdateType.UpdateOverwriteVersion;
+                                    ListItemUtilities.UpdateListItem(listitem, parser, dataRow.Values, updateMode, IsNewItem);
 
                                     if (dataRow.Attachments != null && dataRow.Attachments.Count > 0)
                                     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  |

#### What's in this Pull Request?

This PR fixes an issue with **ObjectListInstanceDataRows** when deploying data rows with security information.

Previously **ObjectListInstanceDataRows** used the update mode **UpdateOverwriteVersion** regardless of the item state (new or existing). **UpdateOverwriteVersion** on a new item causes the server to return a **ListItem** instance with an ID of **-1**. Any subsequent (security) action (for example **BreakRoleInheritance** called by **SetSecurity**) on an item in this state will cause a **ServerException** with an inner exception of the type **InvalidOperationException**. Switching to the update mode **Update** for new items will prevent this from happening.