### PR TITLE
Make properties optional

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/Functional/Validators/ListInstanceValidator.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/Functional/Validators/ListInstanceValidator.cs
@@ -56,7 +56,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Functional.Validators
             foreach (ListInstance list in sourceCollection)
             {
                 // don't add hidden lists since they're not exported again...
-                if (!list.Hidden)
+                if (list.Hidden.HasValue && !list.Hidden.Value)
                 {
                     ProvisioningTemplate pt = new ProvisioningTemplate();
                     pt.Lists.Add(list);

--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectTermGroupsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectTermGroupsTests.cs
@@ -163,7 +163,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
 
                 Assert.IsInstanceOfType(group, typeof(Microsoft.SharePoint.Client.Taxonomy.TermGroup));
                 Assert.IsInstanceOfType(set, typeof(Microsoft.SharePoint.Client.Taxonomy.TermSet));
-                Assert.IsTrue(set.Terms.Count == 2);
+                Assert.AreEqual(2, set.Terms.Count);
 
 
                 var creationInfo = new ProvisioningTemplateCreationInformation(ctx.Web) { BaseTemplate = ctx.Web.GetBaseTemplate() };
@@ -200,6 +200,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
             var reusedTerm = new Term(sourceTerm.Id, "Source Term 1", null, null, null, null, null)
             {
                 IsReused = true,
+                IsSourceTerm = false,
                 SourceTermId = sourceTerm.Id
             };
 

--- a/Core/OfficeDevPnP.Core.Tests/Framework/Providers/XMLProvidersTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/Providers/XMLProvidersTests.cs
@@ -528,7 +528,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual(1, result.ContentTypes.Count);
             Assert.IsNotNull(result.ContentTypes[0].FieldRefs);
             Assert.AreEqual(4, result.ContentTypes[0].FieldRefs.Count);
-            Assert.AreEqual(1, result.ContentTypes[0].FieldRefs.Count(f => f.Required));
+            Assert.AreEqual(1, result.ContentTypes[0].FieldRefs.Count(f => f.Required.HasValue && f.Required.Value));
 
             Assert.IsTrue(result.PropertyBagEntries.Count == 2);
         }
@@ -876,10 +876,10 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual("/Forms/NewForm.aspx", ct.NewFormUrl);
             Assert.AreEqual("/Forms/EditForm.aspx", ct.EditFormUrl);
             Assert.AreEqual("DocumentTemplate.dotx", ct.DocumentTemplate);
-            Assert.IsTrue(ct.Hidden);
+            Assert.IsTrue(ct.Hidden.HasValue && ct.Hidden.Value);
             Assert.IsTrue(ct.Overwrite);
-            Assert.IsTrue(ct.ReadOnly);
-            Assert.IsTrue(ct.Sealed);
+            Assert.IsTrue(ct.ReadOnly.HasValue && ct.ReadOnly.Value);
+            Assert.IsTrue(ct.Sealed.HasValue && ct.Sealed.Value);
 
             Assert.IsNotNull(ct.DocumentSetTemplate);
             Assert.IsNotNull(ct.DocumentSetTemplate.AllowedContentTypes);
@@ -902,8 +902,8 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             var field = ct.FieldRefs.FirstOrDefault(f => f.Name == "TestField");
             Assert.IsNotNull(field);
             Assert.AreEqual(new Guid("23203e97-3bfe-40cb-afb4-07aa2b86bf45"), field.Id);
-            Assert.IsTrue(field.Required);
-            Assert.IsTrue(field.Hidden);
+            Assert.IsTrue(field.Required.HasValue && field.Required.Value);
+            Assert.IsTrue(field.Hidden.HasValue && field.Hidden.Value);
         }
 
 
@@ -1745,8 +1745,8 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual("Test Termset 1 Test Term Group", ts.Description);
             Assert.AreEqual("termset1owner@termgroup1", ts.Owner);
             Assert.AreEqual(1049, ts.Language);
-            Assert.IsTrue(ts.IsAvailableForTagging);
-            Assert.IsTrue(ts.IsOpenForTermCreation);
+            Assert.AreEqual(true, ts.IsAvailableForTagging);
+            Assert.AreEqual(true, ts.IsOpenForTermCreation);
             Assert.IsNotNull(ts.Properties);
             Assert.AreEqual(2, ts.Properties.Count());
             Assert.IsNotNull(ts.Properties.FirstOrDefault(p => p.Key == "Property1"));
@@ -1764,7 +1764,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual(1055, tm.Language);
             Assert.AreEqual("term1owner@termgroup1", tm.Owner);
             Assert.AreEqual(new Guid("bd36d6f6-ee5f-4ce5-961c-93867d8f1f3d"), tm.SourceTermId);
-            Assert.IsTrue(tm.IsAvailableForTagging);
+            Assert.AreEqual(true, tm.IsAvailableForTagging);
             Assert.IsTrue(tm.IsDeprecated);
             Assert.IsTrue(tm.IsReused);
             Assert.IsTrue(tm.IsSourceTerm);
@@ -1813,7 +1813,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.IsNull(tm.Language);
             Assert.AreEqual("term1owner@term2owner", tm.Owner);
             Assert.AreEqual(Guid.Empty, tm.SourceTermId);
-            Assert.IsFalse(tm.IsAvailableForTagging);
+            Assert.AreEqual(false, tm.IsAvailableForTagging);
             Assert.IsFalse(tm.IsDeprecated);
             Assert.IsFalse(tm.IsReused);
             Assert.IsFalse(tm.IsSourceTerm);
@@ -2197,7 +2197,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.IsFalse(wd.RequiresAssociationForm);
             Assert.IsFalse(wd.RequiresInitiationForm);
             Assert.IsNull(wd.RestrictToScope);
-            Assert.AreEqual("Universal", wd.RestrictToType);
+            Assert.IsNull(wd.RestrictToType);
             Assert.IsTrue(wd.Properties == null || wd.Properties.Count == 0);
             Assert.AreEqual("workflow2.xaml", wd.XamlPath);
 
@@ -3006,7 +3006,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual("Resources/Themes/Contoso/Contoso.css", template.WebSettings.AlternateCSS);
             Assert.AreEqual("seattle.master", template.WebSettings.MasterPageUrl);
             Assert.AreEqual("custom.master", template.WebSettings.CustomMasterPageUrl);
-            Assert.IsTrue(template.WebSettings.NoCrawl);
+            Assert.AreEqual(true, template.WebSettings.NoCrawl);
             Assert.AreEqual("admin@contoso.com", template.WebSettings.RequestAccessEmail);
             Assert.AreEqual("Resources/Themes/Contoso/contosologo.png", template.WebSettings.SiteLogo);
             Assert.AreEqual("Contoso Portal", template.WebSettings.Title);
@@ -3085,8 +3085,8 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual(DayOfWeek.Sunday, template.RegionalSettings.FirstDayOfWeek);
             Assert.AreEqual(1, template.RegionalSettings.FirstWeekOfYear);
             Assert.AreEqual(1040, template.RegionalSettings.LocaleId);
-            Assert.IsTrue(template.RegionalSettings.ShowWeeks);
-            Assert.IsTrue(template.RegionalSettings.Time24);
+            Assert.AreEqual(true, template.RegionalSettings.ShowWeeks);
+            Assert.AreEqual(true, template.RegionalSettings.Time24);
             Assert.AreEqual(2, template.RegionalSettings.TimeZone);
             Assert.AreEqual(WorkHour.PM0600, template.RegionalSettings.WorkDayEndHour);
             Assert.AreEqual(5, template.RegionalSettings.WorkDays);
@@ -3238,12 +3238,12 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             var prop = template.PropertyBagEntries.FirstOrDefault(p => p.Key == "KEY1");
             Assert.IsNotNull(prop);
             Assert.AreEqual("value1", prop.Value);
-            Assert.IsTrue(prop.Indexed);
+            Assert.IsTrue(prop.Indexed.HasValue && prop.Indexed.Value);
             Assert.IsTrue(prop.Overwrite);
             prop = template.PropertyBagEntries.FirstOrDefault(p => p.Key == "KEY2");
             Assert.IsNotNull(prop);
             Assert.AreEqual("value2", prop.Value);
-            Assert.IsFalse(prop.Indexed);
+            Assert.IsFalse(prop.Indexed.HasValue && prop.Indexed.Value);
             Assert.IsFalse(prop.Overwrite);
         }
 
@@ -4016,20 +4016,20 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
 
             var l = template.Lists.FirstOrDefault(ls => ls.Title == "Project Documents");
             Assert.IsNotNull(l);
-            Assert.IsTrue(l.ContentTypesEnabled);
+            Assert.AreEqual(true, l.ContentTypesEnabled);
             Assert.AreEqual("Project Documents are stored here", l.Description);
             Assert.AreEqual("document.dotx", l.DocumentTemplate);
             Assert.AreEqual(1, l.DraftVersionVisibility);
-            Assert.IsTrue(l.EnableAttachments);
-            Assert.IsTrue(l.EnableFolderCreation);
-            Assert.IsTrue(l.EnableMinorVersions);
-            Assert.IsTrue(l.EnableModeration);
-            Assert.IsTrue(l.EnableVersioning);
-            Assert.IsTrue(l.ForceCheckout);
-            Assert.IsTrue(l.Hidden);
+            Assert.AreEqual(true, l.EnableAttachments);
+            Assert.AreEqual(true, l.EnableFolderCreation);
+            Assert.AreEqual(true, l.EnableMinorVersions);
+            Assert.AreEqual(true, l.EnableModeration);
+            Assert.AreEqual(true, l.EnableVersioning);
+            Assert.AreEqual(true, l.ForceCheckout);
+            Assert.AreEqual(true, l.Hidden);
             Assert.AreEqual(10, l.MaxVersionLimit);
             Assert.AreEqual(2, l.MinorVersionLimit);
-            Assert.IsTrue(l.OnQuickLaunch);
+            Assert.AreEqual(true, l.OnQuickLaunch);
             Assert.IsTrue(l.RemoveExistingContentTypes);
             Assert.AreEqual(new Guid("30FB193E-016E-45A6-B6FD-C6C2B31AA150"), l.TemplateFeatureID);
             Assert.AreEqual(101, l.TemplateType);
@@ -4200,20 +4200,20 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.IsNotNull(fr);
             Assert.AreEqual(new Guid("23203E97-3BFE-40CB-AFB4-07AA2B86BF45"), fr.Id);
             Assert.AreEqual("Project ID", fr.DisplayName);
-            Assert.IsFalse(fr.Hidden);
-            Assert.IsTrue(fr.Required);
+            Assert.IsFalse(fr.Hidden.HasValue && fr.Hidden.Value);
+            Assert.IsTrue(fr.Required.HasValue && fr.Required.Value);
             fr = l.FieldRefs.FirstOrDefault(f => f.Name == "ProjectName");
             Assert.IsNotNull(fr);
             Assert.AreEqual(new Guid("B01B3DBC-4630-4ED1-B5BA-321BC7841E3D"), fr.Id);
             Assert.AreEqual("Project Name", fr.DisplayName);
-            Assert.IsTrue(fr.Hidden);
-            Assert.IsFalse(fr.Required);
+            Assert.IsTrue(fr.Hidden.HasValue && fr.Hidden.Value);
+            Assert.IsFalse(fr.Required.HasValue && fr.Required.Value);
             fr = l.FieldRefs.FirstOrDefault(f => f.Name == "ProjectManager");
             Assert.IsNotNull(fr);
             Assert.AreEqual(new Guid("A5DE9600-B7A6-42DD-A05E-10D4F1500208"), fr.Id);
             Assert.AreEqual("Project Manager", fr.DisplayName);
-            Assert.IsFalse(fr.Hidden);
-            Assert.IsTrue(fr.Required);
+            Assert.IsFalse(fr.Hidden.HasValue && fr.Hidden.Value);
+            Assert.IsTrue(fr.Required.HasValue && fr.Required.Value);
 #endregion
 
 #region folders

--- a/Core/OfficeDevPnP.Core.Tests/Framework/Providers/XMLSerializer201903Tests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/Providers/XMLSerializer201903Tests.cs
@@ -1759,7 +1759,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual(true, propertyBagEntries[0].Overwrite);
             Assert.AreEqual("KEY1", propertyBagEntries[0].Key);
             Assert.AreEqual("value1", propertyBagEntries[0].Value);
-            Assert.AreEqual(true, propertyBagEntries[1].Indexed);
+            Assert.AreEqual(true, propertyBagEntries[1].Indexed.Value);
         }
 
         [TestMethod]
@@ -2392,10 +2392,10 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual("DocumentTemplate.dotx", ct.DocumentTemplate);
             Assert.AreEqual(new Guid("F1A1715E-6C52-40DE-8403-E9AAFD0470D0"), ct.FieldRefs[3].Id);
             Assert.AreEqual(true, ct.FieldRefs[3].UpdateChildren);
-            Assert.IsFalse(ct.Hidden);
+            Assert.IsFalse(ct.Hidden.HasValue && ct.Hidden.Value);
             Assert.IsFalse(ct.Overwrite);
-            Assert.IsFalse(ct.ReadOnly);
-            Assert.IsFalse(ct.Sealed);
+            Assert.IsFalse(ct.ReadOnly.HasValue && ct.ReadOnly.Value);
+            Assert.IsFalse(ct.Sealed.HasValue && ct.Sealed.Value);
 
             ct = template.ContentTypes.FirstOrDefault(c => c.Id == "0x0120D5200039D83CD2C9BA4A4499AEE6BE3562E023");
             Assert.IsNotNull(ct.DocumentSetTemplate);
@@ -2539,19 +2539,19 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             // common properties
             var list = template.Lists.FirstOrDefault(ls => ls.Title == "{parameter:CompanyName} - Projects");
             Assert.IsNotNull(list);
-            Assert.IsTrue(list.ContentTypesEnabled);
+            Assert.AreEqual(true, list.ContentTypesEnabled);
             Assert.AreEqual("Project Documents are stored here", list.Description);
             Assert.AreEqual(1, list.DraftVersionVisibility);
-            Assert.IsFalse(list.EnableAttachments);
-            Assert.IsTrue(list.EnableFolderCreation);
-            Assert.IsTrue(list.EnableMinorVersions);
-            Assert.IsFalse(list.EnableModeration);
-            Assert.IsTrue(list.EnableVersioning);
-            Assert.IsTrue(list.ForceCheckout);
-            Assert.IsFalse(list.Hidden);
+            Assert.AreEqual(false, list.EnableAttachments);
+            Assert.AreEqual(true, list.EnableFolderCreation);
+            Assert.AreEqual(true, list.EnableMinorVersions);
+            Assert.AreEqual(false, list.EnableModeration);
+            Assert.AreEqual(true, list.EnableVersioning);
+            Assert.AreEqual(true, list.ForceCheckout);
+            Assert.AreEqual(false, list.Hidden);
             Assert.AreEqual(10, list.MaxVersionLimit);
             Assert.AreEqual(10, list.MinorVersionLimit);
-            Assert.IsTrue(list.OnQuickLaunch);
+            Assert.AreEqual(true, list.OnQuickLaunch);
             Assert.IsFalse(list.RemoveExistingContentTypes);
             Assert.AreEqual(Core.Framework.Provisioning.Model.ListExperience.ClassicExperience, list.ListExperience);
             Assert.AreEqual(new Guid("81a7b6a8-c0e9-4819-aea1-8fc8894d3c43"), list.TemplateFeatureID);

--- a/Core/OfficeDevPnP.Core.Tests/Framework/Providers/XMLSerializer201909Tests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/Providers/XMLSerializer201909Tests.cs
@@ -2322,7 +2322,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual(true, propertyBagEntries[0].Overwrite);
             Assert.AreEqual("KEY1", propertyBagEntries[0].Key);
             Assert.AreEqual("value1", propertyBagEntries[0].Value);
-            Assert.AreEqual(true, propertyBagEntries[1].Indexed);
+            Assert.AreEqual(true, propertyBagEntries[1].Indexed.Value);
         }
 
         [TestMethod]
@@ -2955,10 +2955,10 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual("DocumentTemplate.dotx", ct.DocumentTemplate);
             Assert.AreEqual(new Guid("F1A1715E-6C52-40DE-8403-E9AAFD0470D0"), ct.FieldRefs[3].Id);
             Assert.AreEqual(true, ct.FieldRefs[3].UpdateChildren);
-            Assert.IsFalse(ct.Hidden);
+            Assert.IsFalse(ct.Hidden.HasValue && ct.Hidden.Value);
             Assert.IsFalse(ct.Overwrite);
-            Assert.IsFalse(ct.ReadOnly);
-            Assert.IsFalse(ct.Sealed);
+            Assert.IsFalse(ct.ReadOnly.HasValue && ct.ReadOnly.Value);
+            Assert.IsFalse(ct.Sealed.HasValue && ct.Sealed.Value);
 
             ct = template.ContentTypes.FirstOrDefault(c => c.Id == "0x0120D5200039D83CD2C9BA4A4499AEE6BE3562E023");
             Assert.IsNotNull(ct.DocumentSetTemplate);
@@ -3102,19 +3102,19 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             // common properties
             var list = template.Lists.FirstOrDefault(ls => ls.Title == "{parameter:CompanyName} - Projects");
             Assert.IsNotNull(list);
-            Assert.IsTrue(list.ContentTypesEnabled);
+            Assert.AreEqual(true, list.ContentTypesEnabled);
             Assert.AreEqual("Project Documents are stored here", list.Description);
             Assert.AreEqual(1, list.DraftVersionVisibility);
-            Assert.IsFalse(list.EnableAttachments);
-            Assert.IsTrue(list.EnableFolderCreation);
-            Assert.IsTrue(list.EnableMinorVersions);
-            Assert.IsFalse(list.EnableModeration);
-            Assert.IsTrue(list.EnableVersioning);
-            Assert.IsTrue(list.ForceCheckout);
-            Assert.IsFalse(list.Hidden);
+            Assert.AreEqual(false, list.EnableAttachments);
+            Assert.AreEqual(true, list.EnableFolderCreation);
+            Assert.AreEqual(true, list.EnableMinorVersions);
+            Assert.AreEqual(false, list.EnableModeration);
+            Assert.AreEqual(true, list.EnableVersioning);
+            Assert.AreEqual(true, list.ForceCheckout);
+            Assert.AreEqual(false, list.Hidden);
             Assert.AreEqual(10, list.MaxVersionLimit);
             Assert.AreEqual(10, list.MinorVersionLimit);
-            Assert.IsTrue(list.OnQuickLaunch);
+            Assert.AreEqual(true, list.OnQuickLaunch);
             Assert.IsFalse(list.RemoveExistingContentTypes);
             Assert.AreEqual(Core.Framework.Provisioning.Model.ListExperience.ClassicExperience, list.ListExperience);
             Assert.AreEqual(new Guid("81a7b6a8-c0e9-4819-aea1-8fc8894d3c43"), list.TemplateFeatureID);

--- a/Core/OfficeDevPnP.Core.Tests/Resources/Templates/ProvisioningSchema-2017-05-FullSample-01.xml
+++ b/Core/OfficeDevPnP.Core.Tests/Resources/Templates/ProvisioningSchema-2017-05-FullSample-01.xml
@@ -251,7 +251,7 @@
                     IsApplicationList="false"
                     MaxVersionLimit="10"
                     MinorVersionLimit="10"
-                    ReadSecurity="11"
+                    ReadSecurity="1"
                     TemplateFeatureID="81a7b6a8-c0e9-4819-aea1-8fc8894d3c43"
                     ValidationFormula="sample formula here"
                     ValidationMessage="validation message here">
@@ -365,9 +365,9 @@
             />
         </pnp:ListInstance>
         <pnp:ListInstance Title="General Documents"
-                     Description="Project Documents are stored here"
+                     Description=""
                      DocumentTemplate=""
-                     OnQuickLaunch="true"
+                     
                      TemplateType="101"
                      Url="Lists/GeneralDocuments"
                      EnableVersioning="true"

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/AzureActiveDirectory/PasswordProfile.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/AzureActiveDirectory/PasswordProfile.cs
@@ -17,12 +17,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model.AzureActiveDirectory
         /// <summary>
         /// Defines whether to force password change at next sign-in for the user
         /// </summary>
-        public Boolean ForceChangePasswordNextSignIn { get; set; }
+        public Boolean? ForceChangePasswordNextSignIn { get; set; }
 
         /// <summary>
         /// Defines whether to force password change at next sign-in with MFA for the user
         /// </summary>
-        public Boolean ForceChangePasswordNextSignInWithMfa { get; set; }
+        public Boolean? ForceChangePasswordNextSignInWithMfa { get; set; }
 
         /// <summary>
         /// The Password for the user

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/Customizations/PropertyBagEntry.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/Customizations/PropertyBagEntry.cs
@@ -18,7 +18,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Gets or sets the Indexed flag for property bag entry
         /// </summary>
-        public bool Indexed { get; set; }
+        public bool? Indexed { get; set; }
 
         /// <summary>
         /// Gets or sets the Overwrite flag for property bag entry

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/InformationArchitecture/ContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/InformationArchitecture/ContentType.cs
@@ -53,17 +53,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// True to define the content type as hidden. If you define a content type as hidden, SharePoint Foundation does not display that content type on the New button in list views. 
         /// </summary>
-        public bool Hidden { get; set; }
+        public bool? Hidden { get; set; }
 
         /// <summary>
         /// True to prevent changes to this content type. You cannot change the value of this attribute through the user interface, but you can change it in code if you have sufficient rights. You must have site collection administrator rights to unseal a content type. 
         /// </summary>
-        public bool Sealed { get; set; }
+        public bool? Sealed { get; set; }
 
         /// <summary>
         /// True to specify that the content type cannot be edited without explicitly removing the read-only setting. This can be done either in the user interface or in code. 
         /// </summary>
-        public bool ReadOnly { get; set; }
+        public bool? ReadOnly { get; set; }
 
         /// <summary>
         /// True to overwrite an existing content type with the same ID.

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/InformationArchitecture/ContentTypeBinding.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/InformationArchitecture/ContentTypeBinding.cs
@@ -32,7 +32,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Declares if the Content Type should be Hidden from New button of the list or library, optional attribute.
         /// </summary>
-        public bool Hidden { get; set; }
+        public bool? Hidden { get; set; }
 
         #endregion
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/InformationArchitecture/FieldRef.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/InformationArchitecture/FieldRef.cs
@@ -36,12 +36,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Gets or sets if the field is Required
         /// </summary>
-        public bool Required { get; set; }
+        public bool? Required { get; set; }
 
         /// <summary>
         /// Gets or sets if the field is Hidden
         /// </summary>
-        public bool Hidden { get; set; }
+        public bool? Hidden { get; set; }
 
         /// <summary>
         /// Declares if the FieldRef should be Removed from the list or library, optional attribute.

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/InformationArchitecture/IRMSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/InformationArchitecture/IRMSettings.cs
@@ -16,57 +16,57 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Defines whether the IRM settings have to be enabled or not.
         /// </summary>
-        public Boolean Enabled { get; set; }
+        public Boolean? Enabled { get; set; }
 
         /// <summary>
         /// Defines whether a viewer can print the downloaded document.
         /// </summary>
-        public Boolean AllowPrint { get; set; }
+        public Boolean? AllowPrint { get; set; }
 
         /// <summary>
         /// Defines whether a viewer can run a script on the downloaded document.
         /// </summary>
-        public Boolean AllowScript { get; set; }
+        public Boolean? AllowScript { get; set; }
 
         /// <summary>
         /// Defines whether a viewer can write on a copy of the downloaded document.
         /// </summary>
-        public Boolean AllowWriteCopy { get; set; }
+        public Boolean? AllowWriteCopy { get; set; }
 
         /// <summary>
         /// Defines whether to block Office Web Application Companion applications (WACs) from showing this document.
         /// </summary>
-        public Boolean DisableDocumentBrowserView { get; set; }
+        public Boolean? DisableDocumentBrowserView { get; set; }
 
         /// <summary>
         /// Defines the number of days after which the downloaded document will expire.
         /// </summary>
-        public Int32 DocumentAccessExpireDays { get; set; }
+        public Int32? DocumentAccessExpireDays { get; set; }
 
         /// <summary>
         /// Defines the expire days for the Information Rights Management (IRM) protection of this document library will expire.
         /// </summary>
-        public Int32 DocumentLibraryProtectionExpiresInDays { get; set; }
+        public Int32? DocumentLibraryProtectionExpiresInDays { get; set; }
 
         /// <summary>
         /// Defines whether the downloaded document will expire.
         /// </summary>
-        public Boolean EnableDocumentAccessExpire { get; set; }
+        public Boolean? EnableDocumentAccessExpire { get; set; }
 
         /// <summary>
         /// Defines whether to enable Office Web Application Companion applications (WACs) to publishing view.
         /// </summary>
-        public Boolean EnableDocumentBrowserPublishingView { get; set; }
+        public Boolean? EnableDocumentBrowserPublishingView { get; set; }
 
         /// <summary>
         /// Defines whether the permission of the downloaded document is applicable to a group.
         /// </summary>
-        public Boolean EnableGroupProtection { get; set; }
+        public Boolean? EnableGroupProtection { get; set; }
 
         /// <summary>
         /// Defines whether a user must verify their credentials after some interval.
         /// </summary>
-        public Boolean EnableLicenseCacheExpire { get; set; }
+        public Boolean? EnableLicenseCacheExpire { get; set; }
 
         /// <summary>
         /// Defines the group name (email address) that the permission is also applicable to.
@@ -76,7 +76,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Defines the number of days that the application that opens the document caches the IRM license. When these elapse, the application will connect to the IRM server to validate the license.
         /// </summary>
-        public Int32 LicenseCacheExpireDays { get; set; }
+        public Int32? LicenseCacheExpireDays { get; set; }
 
         /// <summary>
         /// Defines the permission policy description.

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/InformationArchitecture/ListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/InformationArchitecture/ListInstance.cs
@@ -146,7 +146,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Gets or sets a value that specifies whether the new list is displayed on the Quick Launch of the site.
         /// </summary>
-        public bool OnQuickLaunch { get; set; }
+        public bool? OnQuickLaunch { get; set; }
 
         /// <summary>
         /// Gets or sets a value that specifies the list server template of the new list.
@@ -162,32 +162,32 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Gets or sets whether verisioning is enabled on the list
         /// </summary>
-        public bool EnableVersioning { get; set; }
+        public bool? EnableVersioning { get; set; }
 
         /// <summary>
         /// Gets or sets whether minor verisioning is enabled on the list
         /// </summary>
-        public bool EnableMinorVersions { get; set; }
+        public bool? EnableMinorVersions { get; set; }
 
         /// <summary>
         /// Gets or sets the DraftVersionVisibility for the list
         /// </summary>
-        public int DraftVersionVisibility { get; set; }
+        public int? DraftVersionVisibility { get; set; }
 
         /// <summary>
         /// Gets or sets whether moderation/content approval is enabled on the list
         /// </summary>
-        public bool EnableModeration { get; set; }
+        public bool? EnableModeration { get; set; }
 
         /// <summary>
         /// Gets or sets the MinorVersionLimit  for versioning, just in case it is enabled on the list
         /// </summary>
-        public int MinorVersionLimit { get; set; }
+        public int? MinorVersionLimit { get; set; }
 
         /// <summary>
         /// Gets or sets the MinorVersionLimit  for verisioning, just in case it is enabled on the list
         /// </summary>
-        public int MaxVersionLimit { get; set; }
+        public int? MaxVersionLimit { get; set; }
 
         /// <summary>
         /// Gets or sets whether existing content types should be removed
@@ -202,35 +202,28 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Gets or sets whether content types are enabled
         /// </summary>
-        public bool ContentTypesEnabled { get; set; }
+        public bool? ContentTypesEnabled { get; set; }
 
         /// <summary>
         /// Gets or sets whether to hide the list
         /// </summary>
-        public bool Hidden { get; set; }
+        public bool? Hidden { get; set; }
 
         /// <summary>
         /// Gets or sets whether to force checkout of documents in the library
         /// </summary>
-        public bool ForceCheckout { get; set; } = false;
+        public bool? ForceCheckout { get; set; }
 
         /// <summary>
         /// Gets or sets whether attachments are enabled. Defaults to true.
         /// </summary>
-        public bool EnableAttachments
-        {
-            get { return _enableAttachments; }
-            set { _enableAttachments = value; }
-        }
+        public bool? EnableAttachments { get; set; }
 
         /// <summary>
         /// Gets or sets whether folder is enabled. Defaults to true.
         /// </summary>
-        public bool EnableFolderCreation
-        {
-            get { return _enableFolderCreation; }
-            set { _enableFolderCreation = value; }
-        }
+        public bool? EnableFolderCreation { get; set; }
+
         /// <summary>
         /// Gets or sets the content types to associate to the list
         /// </summary>
@@ -356,12 +349,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Defines if the current list or library has to be included in crawling, optional attribute.
         /// </summary>
-        public Boolean NoCrawl { get; set; }
+        public Boolean? NoCrawl { get; set; }
 
         /// <summary>
         /// Defines the current list UI/UX experience (valid for SPO only).
         /// </summary>
-        public ListExperience ListExperience { get; set; }
+        public ListExperience? ListExperience { get; set; }
 
         /// <summary>
         /// Defines a value that specifies the location of the default display form for the list.
@@ -381,7 +374,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Defines a value that specifies the reading order of the list.
         /// </summary>
-        public ListReadingDirection Direction { get; set; }
+        public ListReadingDirection? Direction { get; set; }
 
         /// <summary>
         /// Defines a value that specifies the URI for the icon of the list, optional attribute.
@@ -391,27 +384,27 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Defines if IRM Expire property, optional attribute.
         /// </summary>
-        public Boolean IrmExpire { get; set; }
+        public Boolean? IrmExpire { get; set; }
 
         /// <summary>
         /// Defines the IRM Reject property, optional attribute.
         /// </summary>
-        public Boolean IrmReject { get; set; }
+        public Boolean? IrmReject { get; set; }
 
         /// <summary>
         /// Defines a value that specifies a flag that a client application can use to determine whether to display the list, optional attribute.
         /// </summary>
-        public Boolean IsApplicationList { get; set; }
+        public Boolean? IsApplicationList { get; set; }
 
         /// <summary>
         /// Defines the Read Security property, optional attribute.
         /// </summary>
-        public Int32 ReadSecurity { get; set; }
+        public Int32? ReadSecurity { get; set; }
 
         /// <summary>
         /// Defines the Write Security property, optional attribute.
         /// </summary>
-        public Int32 WriteSecurity { get; set; }
+        public Int32? WriteSecurity { get; set; }
 
         /// <summary>
         /// Defines a value that specifies the data validation criteria for a list item, optional attribute.

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/ModernExperiences/SiteHeader.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/ModernExperiences/SiteHeader.cs
@@ -21,12 +21,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Defines the Menu Style
         /// </summary>
-        public SiteHeaderMenuStyle MenuStyle { get; set; }
+        public SiteHeaderMenuStyle? MenuStyle { get; set; }
 
         /// <summary>
         /// Defines the Background Emphasis of the Header
         /// </summary>
-        public Emphasis BackgroundEmphasis { get; set; }
+        public Emphasis? BackgroundEmphasis { get; set; }
 
         #endregion
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/Navigation/Navigation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/Navigation/Navigation.cs
@@ -83,17 +83,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Declares whether the tree view has to be enabled at the site level or not, optional attribute.
         /// </summary>
-        public Boolean EnableTreeView { get; set; }
+        public Boolean? EnableTreeView { get; set; }
 
         /// <summary>
         /// Declares whether the New Page ribbon command will automatically create a navigation item for the newly created page, optional attribute.
         /// </summary>
-        public Boolean AddNewPagesToNavigation { get; set; }
+        public Boolean? AddNewPagesToNavigation { get; set; }
 
         /// <summary>
         /// Declares whether the New Page ribbon command will automatically create a friendly URL for the newly created page, optional attribute.
         /// </summary>
-        public Boolean CreateFriendlyUrlsForNewPages { get; set; }
+        public Boolean? CreateFriendlyUrlsForNewPages { get; set; }
 
         #endregion
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/Settings/RegionalSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/Settings/RegionalSettings.cs
@@ -34,67 +34,67 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// The number of days to extend or reduce the current month in Hijri calendars
         /// </summary>
-        public Int32 AdjustHijriDays { get; set; }
+        public Int32? AdjustHijriDays { get; set; }
 
         /// <summary>
         /// The Alternate Calendar type that is used on the server
         /// </summary>
-        public Microsoft.SharePoint.Client.CalendarType AlternateCalendarType { get; set; }
+        public Microsoft.SharePoint.Client.CalendarType? AlternateCalendarType { get; set; }
 
         /// <summary>
         /// The Calendar Type that is used on the server
         /// </summary>
-        public Microsoft.SharePoint.Client.CalendarType CalendarType { get; set; }
+        public Microsoft.SharePoint.Client.CalendarType? CalendarType { get; set; }
 
         /// <summary>
         /// The Collation that is used on the site
         /// </summary>
-        public Int32 Collation { get; set; }
+        public Int32? Collation { get; set; }
 
         /// <summary>
         /// The First Day of the Week used in calendars on the server
         /// </summary>
-        public DayOfWeek FirstDayOfWeek { get; set; }
+        public DayOfWeek? FirstDayOfWeek { get; set; }
 
         /// <summary>
         /// The First Week of the Year used in calendars on the server
         /// </summary>
-        public Int32 FirstWeekOfYear { get; set; }
+        public Int32? FirstWeekOfYear { get; set; }
 
         /// <summary>
         /// The Locale Identifier in use on the server
         /// </summary>
-        public Int32 LocaleId { get; set; }
+        public Int32? LocaleId { get; set; }
 
         /// <summary>
         /// Defines whether to display the week number in day or week views of a calendar
         /// </summary>
-        public Boolean ShowWeeks { get; set; }
+        public Boolean? ShowWeeks { get; set; }
 
         /// <summary>
         /// Defines whether to use a 24-hour time format in representing the hours of the day
         /// </summary>
-        public Boolean Time24 { get; set; }
+        public Boolean? Time24 { get; set; }
 
         /// <summary>
         /// The Time Zone that is used on the server
         /// </summary>
-        public Int32 TimeZone { get; set; }
+        public Int32? TimeZone { get; set; }
 
         /// <summary>
         /// The the default hour at which the work day ends on the calendar that is in use on the server
         /// </summary>
-        public WorkHour WorkDayEndHour { get; set; }
+        public WorkHour? WorkDayEndHour { get; set; }
 
         /// <summary>
         /// The work days of Web site calendars
         /// </summary>
-        public Int32 WorkDays { get; set; }
+        public Int32? WorkDays { get; set; }
 
         /// <summary>
         /// The the default hour at which the work day starts on the calendar that is in use on the server
         /// </summary>
-        public WorkHour WorkDayStartHour { get; set; }
+        public WorkHour? WorkDayStartHour { get; set; }
 
         #endregion
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/Settings/WebSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/Settings/WebSettings.cs
@@ -17,7 +17,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Defines whether the site has to be crawled or not
         /// </summary>
-        public Boolean NoCrawl { get; set; }
+        public Boolean? NoCrawl { get; set; }
 
         /// <summary>
         /// The email address to which any access request will be sent
@@ -67,12 +67,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Defines whether the comments on site pages are disabled or not
         /// </summary>
-        public Boolean CommentsOnSitePagesDisabled { get; set; }
+        public Boolean? CommentsOnSitePagesDisabled { get; set; }
 
         /// <summary>
         /// Enables or disables the QuickLaunch for the site
         /// </summary>
-        public Boolean QuickLaunchEnabled { get; set; }
+        public Boolean? QuickLaunchEnabled { get; set; }
 
         /// <summary>
         /// Defines the list of Alternate UI Cultures for the current web
@@ -82,47 +82,47 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Defines whether to enable Multilingual capabilities for the current web
         /// </summary>
-        public bool IsMultilingual { get; set; }
+        public bool? IsMultilingual { get; set; }
 
         /// <summary>
         /// Defines whether to OverwriteTranslationsOnChange on change for the current web
         /// </summary>
-        public bool OverwriteTranslationsOnChange { get; set; }
+        public bool? OverwriteTranslationsOnChange { get; set; }
 
         /// <summary>
         /// Defines whether to exclude the web from offline client
         /// </summary>
-        public bool ExcludeFromOfflineClient { get; set; }
+        public bool? ExcludeFromOfflineClient { get; set; }
 
         /// <summary>
         /// Defines whether members can share content from the current web
         /// </summary>
-        public bool MembersCanShare { get; set; }
+        public bool? MembersCanShare { get; set; }
 
         /// <summary>
         /// Defines whether disable flows for the current web
         /// </summary>
-        public bool DisableFlows { get; set; }
+        public bool? DisableFlows { get; set; }
 
         /// <summary>
         /// Defines whether disable PowerApps for the current web
         /// </summary>
-        public bool DisableAppViews { get; set; }
+        public bool? DisableAppViews { get; set; }
 
         /// <summary>
         /// Defines whether to enable the Horizontal QuickLaunch for the current web
         /// </summary>
-        public bool HorizontalQuickLaunch { get; set; }
+        public bool? HorizontalQuickLaunch { get; set; }
 
         /// <summary>
         /// Defines the SearchScope for the site
         /// </summary>
-        public SearchScopes SearchScope { get; set; }
+        public SearchScopes? SearchScope { get; set; }
 
         /// <summary>
         /// Define if the suitebar search box should show or not 
         /// </summary>
-        public SearchBoxInNavBar SearchBoxInNavBar { get; set; }
+        public SearchBoxInNavBar? SearchBoxInNavBar { get; set; }
 
         #endregion
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/Taxonomy/Term.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/Taxonomy/Term.cs
@@ -38,7 +38,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Gets or sets the IsAvailableForTagging flag for the term
         /// </summary>
-        public Boolean IsAvailableForTagging { get; set; }
+        public Boolean? IsAvailableForTagging { get; set; }
         /// <summary>
         /// Gets or sets the IsReused flag for the term
         /// </summary>
@@ -105,6 +105,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         {
             this._terms = new TermCollection(this.ParentTemplate);
             this._labels = new TermLabelCollection(this.ParentTemplate);
+            this.IsSourceTerm = true;
         }
 
         /// <summary>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/Taxonomy/TermSet.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/SharePoint/Taxonomy/TermSet.cs
@@ -37,11 +37,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Gets or sets the IsOpenForTermCreation flag for the termset
         /// </summary>
-        public bool IsOpenForTermCreation { get; set; }
+        public bool? IsOpenForTermCreation { get; set; }
         /// <summary>
         /// Gets or sets the IsAvailableForTagging flag for the termset
         /// </summary>
-        public bool IsAvailableForTagging { get; set; }
+        public bool? IsAvailableForTagging { get; set; }
         /// <summary>
         /// Gets or sets the termset owner
         /// </summary>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/Team.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/Team.cs
@@ -54,7 +54,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model.Teams
         /// </summary>
         public TeamAppInstanceCollection Apps { get; private set; }
 
-        public TeamSpecialization Specialization { get; set; }
+        public TeamSpecialization? Specialization { get; set; }
 
         /// <summary>
         /// Declares the ID of the targt Group/Team to update, optional attribute. Cannot be used together with CloneFrom.
@@ -69,7 +69,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model.Teams
         /// <summary>
         /// Declares whether the Team is archived or not
         /// </summary>
-        public Boolean Archived { get; set; }
+        public Boolean? Archived { get; set; }
 
         /// <summary>
         /// Declares the nickname for the Team, optional attribute

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/TeamDiscoverySettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/TeamDiscoverySettings.cs
@@ -16,7 +16,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model.Teams
         /// <summary>
         /// Defines whether the Team is visible via search and suggestions from the Teams client
         /// </summary>
-        public Boolean ShowInTeamsSearchAndSuggestions { get; set; }
+        public Boolean? ShowInTeamsSearchAndSuggestions { get; set; }
 
         #endregion
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/TeamFunSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/TeamFunSettings.cs
@@ -22,7 +22,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model.Teams
         /// <summary>
         /// Defines whether Giphys are consented or not
         /// </summary>
-        public Boolean AllowGiphy { get; set; }
+        public Boolean? AllowGiphy { get; set; }
 
         /// <summary>
         /// Defines the Content Rating for Giphys
@@ -42,12 +42,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model.Teams
         /// <summary>
         /// Defines whether Stickers and Memes are consented or not
         /// </summary>
-        public Boolean AllowStickersAndMemes { get; set; }
+        public Boolean? AllowStickersAndMemes { get; set; }
 
         /// <summary>
         /// Defines whether Custom Memes are consented or not
         /// </summary>
-        public Boolean AllowCustomMemes { get; set; }
+        public Boolean? AllowCustomMemes { get; set; }
 
         #endregion
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/TeamGuestSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/TeamGuestSettings.cs
@@ -16,12 +16,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model.Teams
         /// <summary>
         /// Defines whether Guests are allowed to create Channels or not
         /// </summary>
-        public Boolean AllowCreateUpdateChannels { get; set; }
+        public Boolean? AllowCreateUpdateChannels { get; set; }
 
         /// <summary>
         /// Defines whether Guests are allowed to delete Channels or not
         /// </summary>
-        public Boolean AllowDeleteChannels { get; set; }
+        public Boolean? AllowDeleteChannels { get; set; }
 
         #endregion
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/TeamMemberSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/TeamMemberSettings.cs
@@ -16,27 +16,27 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model.Teams
         /// <summary>
         /// Defines if members can add and update channels
         /// </summary>
-        public Boolean AllowCreateUpdateChannels { get; set; }
+        public Boolean? AllowCreateUpdateChannels { get; set; }
 
         /// <summary>
         /// Defines if members can delete channels
         /// </summary>
-        public Boolean AllowDeleteChannels { get; set; }
+        public Boolean? AllowDeleteChannels { get; set; }
 
         /// <summary>
         /// Defines if members can add and remove apps
         /// </summary>
-        public Boolean AllowAddRemoveApps { get; set; }
+        public Boolean? AllowAddRemoveApps { get; set; }
 
         /// <summary>
         /// Defines if members can add, update, and remove tabs
         /// </summary>
-        public Boolean AllowCreateUpdateRemoveTabs { get; set; }
+        public Boolean? AllowCreateUpdateRemoveTabs { get; set; }
 
         /// <summary>
         /// Defines if members can add, update, and remove connectors
         /// </summary>
-        public Boolean AllowCreateUpdateRemoveConnectors { get; set; }
+        public Boolean? AllowCreateUpdateRemoveConnectors { get; set; }
 
         #endregion
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/TeamMessagingSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/TeamMessagingSettings.cs
@@ -16,27 +16,27 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model.Teams
         /// <summary>
         /// Defines if users can edit their messages
         /// </summary>
-        public Boolean AllowUserEditMessages { get; set; }
+        public Boolean? AllowUserEditMessages { get; set; }
 
         /// <summary>
         /// Defines if users can delete their messages
         /// </summary>
-        public Boolean AllowUserDeleteMessages { get; set; }
+        public Boolean? AllowUserDeleteMessages { get; set; }
 
         /// <summary>
         /// Defines if owners can delete any message
         /// </summary>
-        public Boolean AllowOwnerDeleteMessages { get; set; }
+        public Boolean? AllowOwnerDeleteMessages { get; set; }
 
         /// <summary>
         /// Defines if @team mentions are allowed
         /// </summary>
-        public Boolean AllowTeamMentions { get; set; }
+        public Boolean? AllowTeamMentions { get; set; }
 
         /// <summary>
         /// Defines if @channel mentions are allowed
         /// </summary>
-        public Boolean AllowChannelMentions { get; set; }
+        public Boolean? AllowChannelMentions { get; set; }
 
         #endregion
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/TeamSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/TeamSecurity.cs
@@ -37,7 +37,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model.Teams
         /// <summary>
         /// Defines whether guests are allowed in the Team
         /// </summary>
-        public Boolean AllowToAddGuests { get; set; }
+        public Boolean? AllowToAddGuests { get; set; }
 
         #endregion
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
@@ -145,8 +145,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     web.Context.Load(navigationSettings, ns => ns.CurrentNavigation, ns => ns.GlobalNavigation);
                     web.Context.ExecuteQueryRetry();
 
-                    navigationSettings.AddNewPagesToNavigation = template.Navigation.AddNewPagesToNavigation;
-                    navigationSettings.CreateFriendlyUrlsForNewPages = template.Navigation.CreateFriendlyUrlsForNewPages;
+                    if (template.Navigation.AddNewPagesToNavigation.HasValue)
+                    {
+                        navigationSettings.AddNewPagesToNavigation = template.Navigation.AddNewPagesToNavigation.Value;
+                    }
+                    if (template.Navigation.CreateFriendlyUrlsForNewPages.HasValue)
+                    {
+                        navigationSettings.CreateFriendlyUrlsForNewPages = template.Navigation.CreateFriendlyUrlsForNewPages.Value;
+                    }
 
                     if (!isNoScriptSite)
                     {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPropertyBagEntry.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPropertyBagEntry.cs
@@ -55,7 +55,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         {
                             scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_PropertyBagEntries_Overwriting_existing_propertybag_entry__0__with_value__1_, propbagEntry.Key, propbagEntry.Value);
                             web.SetPropertyBagValue(propbagEntry.Key, parser.ParseString(propbagEntry.Value));
-                            if (propbagEntry.Indexed)
+                            if (propbagEntry.Indexed.HasValue && propbagEntry.Indexed.Value)
                             {
                                 web.AddIndexedPropertyBagKey(propbagEntry.Key);
                             }
@@ -65,9 +65,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     {
                         if (!propExists)
                         {
-                            scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_PropertyBagEntries_Creating_new_propertybag_entry__0__with_value__1__2_, propbagEntry.Key, propbagEntry.Value, propbagEntry.Indexed ? ",Indexed = true" : "");
+                            scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_PropertyBagEntries_Creating_new_propertybag_entry__0__with_value__1__2_, propbagEntry.Key, propbagEntry.Value, propbagEntry.Indexed.GetValueOrDefault() ? ",Indexed = true" : "");
                             web.SetPropertyBagValue(propbagEntry.Key, parser.ParseString(propbagEntry.Value));
-                            if (propbagEntry.Indexed)
+                            if (propbagEntry.Indexed.HasValue && propbagEntry.Indexed.Value)
                             {
                                 web.AddIndexedPropertyBagKey(propbagEntry.Key);
                             }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectRegionalSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectRegionalSettings.cs
@@ -60,72 +60,72 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 web.Context.ExecuteQueryRetry();
 
                 var isDirty = false;
-                if (web.RegionalSettings.AdjustHijriDays != template.RegionalSettings.AdjustHijriDays)
+                if (template.RegionalSettings.AdjustHijriDays.HasValue && web.RegionalSettings.AdjustHijriDays != template.RegionalSettings.AdjustHijriDays.Value)
                 {
-                    web.RegionalSettings.AdjustHijriDays = Convert.ToInt16(template.RegionalSettings.AdjustHijriDays);
+                    web.RegionalSettings.AdjustHijriDays = Convert.ToInt16(template.RegionalSettings.AdjustHijriDays.Value);
                     isDirty = true;
                 }
-                if (web.RegionalSettings.AlternateCalendarType != (short)template.RegionalSettings.AlternateCalendarType)
+                if (template.RegionalSettings.AlternateCalendarType.HasValue && web.RegionalSettings.AlternateCalendarType != (short)template.RegionalSettings.AlternateCalendarType.Value)
                 {
-                    web.RegionalSettings.AlternateCalendarType = (short)template.RegionalSettings.AlternateCalendarType;
+                    web.RegionalSettings.AlternateCalendarType = (short)template.RegionalSettings.AlternateCalendarType.Value;
                     isDirty = true;
                 }
-                if (template.RegionalSettings.CalendarType != CalendarType.None)
+                if (template.RegionalSettings.CalendarType.HasValue && template.RegionalSettings.CalendarType != CalendarType.None)
                 {
-                    if (web.RegionalSettings.CalendarType != (short)template.RegionalSettings.CalendarType)
+                    if (web.RegionalSettings.CalendarType != (short)template.RegionalSettings.CalendarType.Value)
                     {
-                        web.RegionalSettings.CalendarType = (short)template.RegionalSettings.CalendarType;
+                        web.RegionalSettings.CalendarType = (short)template.RegionalSettings.CalendarType.Value;
                         isDirty = true;
                     }
                 }
-                if (web.RegionalSettings.Collation != Convert.ToInt16(template.RegionalSettings.Collation))
+                if (template.RegionalSettings.Collation.HasValue && web.RegionalSettings.Collation != Convert.ToInt16(template.RegionalSettings.Collation.Value))
                 {
-                    web.RegionalSettings.Collation = Convert.ToInt16(template.RegionalSettings.Collation);
+                    web.RegionalSettings.Collation = Convert.ToInt16(template.RegionalSettings.Collation.Value);
                     isDirty = true;
                 }
-                if (web.RegionalSettings.FirstDayOfWeek != (uint)template.RegionalSettings.FirstDayOfWeek)
+                if (template.RegionalSettings.FirstDayOfWeek.HasValue && web.RegionalSettings.FirstDayOfWeek != (uint)template.RegionalSettings.FirstDayOfWeek.Value)
                 {
-                    web.RegionalSettings.FirstDayOfWeek = (uint)template.RegionalSettings.FirstDayOfWeek;
+                    web.RegionalSettings.FirstDayOfWeek = (uint)template.RegionalSettings.FirstDayOfWeek.Value;
                     isDirty = true;
                 }
-                if (web.RegionalSettings.FirstWeekOfYear != Convert.ToInt16(template.RegionalSettings.FirstWeekOfYear))
+                if (template.RegionalSettings.FirstWeekOfYear.HasValue && web.RegionalSettings.FirstWeekOfYear != Convert.ToInt16(template.RegionalSettings.FirstWeekOfYear.Value))
                 {
-                    web.RegionalSettings.FirstWeekOfYear = Convert.ToInt16(template.RegionalSettings.FirstWeekOfYear);
+                    web.RegionalSettings.FirstWeekOfYear = Convert.ToInt16(template.RegionalSettings.FirstWeekOfYear.Value);
                     isDirty = true;
                 }
-                if (template.RegionalSettings.LocaleId > 0 && (web.RegionalSettings.LocaleId != Convert.ToUInt32(template.RegionalSettings.LocaleId)))
+                if (template.RegionalSettings.LocaleId.HasValue && template.RegionalSettings.LocaleId > 0 && (web.RegionalSettings.LocaleId != Convert.ToUInt32(template.RegionalSettings.LocaleId.Value)))
                 {
-                    web.RegionalSettings.LocaleId = Convert.ToUInt32(template.RegionalSettings.LocaleId);
+                    web.RegionalSettings.LocaleId = Convert.ToUInt32(template.RegionalSettings.LocaleId.Value);
                     isDirty = true;
                 }
-                if (web.RegionalSettings.ShowWeeks != template.RegionalSettings.ShowWeeks)
+                if (template.RegionalSettings.ShowWeeks.HasValue && web.RegionalSettings.ShowWeeks != template.RegionalSettings.ShowWeeks.Value)
                 {
-                    web.RegionalSettings.ShowWeeks = template.RegionalSettings.ShowWeeks;
+                    web.RegionalSettings.ShowWeeks = template.RegionalSettings.ShowWeeks.Value;
                     isDirty = true;
                 }
-                if (web.RegionalSettings.Time24 != template.RegionalSettings.Time24)
+                if (template.RegionalSettings.Time24.HasValue && web.RegionalSettings.Time24 != template.RegionalSettings.Time24.Value)
                 {
-                    web.RegionalSettings.Time24 = template.RegionalSettings.Time24;
+                    web.RegionalSettings.Time24 = template.RegionalSettings.Time24.Value;
                     isDirty = true;
                 }
-                if (template.RegionalSettings.TimeZone != 0 && (web.RegionalSettings.TimeZone.Id != template.RegionalSettings.TimeZone))
+                if (template.RegionalSettings.TimeZone.HasValue && template.RegionalSettings.TimeZone != 0 && (web.RegionalSettings.TimeZone.Id != template.RegionalSettings.TimeZone.Value))
                 {
-                    web.RegionalSettings.TimeZone = web.RegionalSettings.TimeZones.GetById(template.RegionalSettings.TimeZone);
+                    web.RegionalSettings.TimeZone = web.RegionalSettings.TimeZones.GetById(template.RegionalSettings.TimeZone.Value);
                     isDirty = true;
                 }
-                if (web.RegionalSettings.WorkDayEndHour != (short)template.RegionalSettings.WorkDayEndHour)
+                if (template.RegionalSettings.WorkDayEndHour.HasValue && web.RegionalSettings.WorkDayEndHour != (short)template.RegionalSettings.WorkDayEndHour.Value)
                 {
-                    web.RegionalSettings.WorkDayEndHour = (short)template.RegionalSettings.WorkDayEndHour;
+                    web.RegionalSettings.WorkDayEndHour = (short)template.RegionalSettings.WorkDayEndHour.Value;
                     isDirty = true;
                 }
-                if (template.RegionalSettings.WorkDays > 0 && (web.RegionalSettings.WorkDays != Convert.ToInt16(template.RegionalSettings.WorkDays)))
+                if (template.RegionalSettings.WorkDays.HasValue && template.RegionalSettings.WorkDays > 0 && (web.RegionalSettings.WorkDays != Convert.ToInt16(template.RegionalSettings.WorkDays.Value)))
                 {
-                    web.RegionalSettings.WorkDays = Convert.ToInt16(template.RegionalSettings.WorkDays);
+                    web.RegionalSettings.WorkDays = Convert.ToInt16(template.RegionalSettings.WorkDays.Value);
                     isDirty = true;
                 }
-                if (web.RegionalSettings.WorkDayStartHour != (short)template.RegionalSettings.WorkDayStartHour)
+                if (template.RegionalSettings.WorkDayStartHour.HasValue && web.RegionalSettings.WorkDayStartHour != (short)template.RegionalSettings.WorkDayStartHour.Value)
                 {
-                    web.RegionalSettings.WorkDayStartHour = (short)template.RegionalSettings.WorkDayStartHour;
+                    web.RegionalSettings.WorkDayStartHour = (short)template.RegionalSettings.WorkDayStartHour.Value;
                     isDirty = true;
                 }
                 if (isDirty)

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteHeaderSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteHeaderSettings.cs
@@ -70,8 +70,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 break;
                             }
                     }
-                    web.HeaderEmphasis = (SPVariantThemeType)Enum.Parse(typeof(SPVariantThemeType), template.Header.BackgroundEmphasis.ToString());
-                    web.MegaMenuEnabled = template.Header.MenuStyle == SiteHeaderMenuStyle.MegaMenu;
+                    if (template.Header.BackgroundEmphasis.HasValue)
+                    {
+                        web.HeaderEmphasis = (SPVariantThemeType)Enum.Parse(typeof(SPVariantThemeType), template.Header.BackgroundEmphasis.ToString());
+                    }
+                    if (template.Header.MenuStyle.HasValue)
+                    {
+                        web.MegaMenuEnabled = template.Header.MenuStyle == SiteHeaderMenuStyle.MegaMenu;
+                    }
                     web.Update();
                     web.Context.ExecuteQueryRetry();
                 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -90,7 +90,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 if (!SetTeamPhoto(scope, parser, connector, team, teamId, accessToken)) return null;
 
                 // Call Archive or Unarchive for the current Team
-                ArchiveTeam(scope, teamId, team.Archived, accessToken);
+                if(team.Archived.HasValue)
+                {
+                    ArchiveTeam(scope, teamId, team.Archived.Value, accessToken);
+                }
 
                 try
                 {
@@ -453,7 +456,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         /// <returns>Whether the Security settings have been provisioned or not</returns>
         private static bool SetGroupSecurity(PnPMonitoredScope scope, Team team, string teamId, string accessToken)
         {
-            SetAllowToAddGuestsSetting(scope, teamId, team.Security.AllowToAddGuests, accessToken);
+            if (team.Security.AllowToAddGuests.HasValue)
+            {
+                SetAllowToAddGuestsSetting(scope, teamId, team.Security.AllowToAddGuests.Value, accessToken);
+            }
 
             string[] desideredOwnerIds;
             string[] desideredMemberIds;
@@ -785,7 +791,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 channel.Description,
                 channel.DisplayName,
-                channel.IsFavoriteByDefault
+                IsFavoriteByDefault = channel.IsFavoriteByDefault.GetValueOrDefault(false)
             };
 
             var channelId = GraphHelper.CreateOrUpdateGraphObject(scope,

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Online.SharePoint.TenantAdministration;
 using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.Diagnostics;
+using OfficeDevPnP.Core.Extensions;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities;
 using OfficeDevPnP.Core.Utilities;
@@ -343,50 +344,30 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 #if !SP2013 && !SP2016
                     if (!isNoScriptSite)
                     {
-                        web.NoCrawl = webSettings.NoCrawl;
+                        if (webSettings.NoCrawl.HasValue)
+                        {
+                            web.NoCrawl = webSettings.NoCrawl.Value;
+                        }
                     }
                     else
                     {
                         scope.LogWarning(CoreResources.Provisioning_ObjectHandlers_WebSettings_SkipNoCrawlUpdate);
                     }
 
-                    if (web.CommentsOnSitePagesDisabled != webSettings.CommentsOnSitePagesDisabled)
-                    {
-                        web.CommentsOnSitePagesDisabled = webSettings.CommentsOnSitePagesDisabled;
-                    }
-
-                    if (web.ExcludeFromOfflineClient != webSettings.ExcludeFromOfflineClient)
-                    {
-                        web.ExcludeFromOfflineClient = webSettings.ExcludeFromOfflineClient;
-                    }
-
-                    if (web.MembersCanShare != webSettings.MembersCanShare)
-                    {
-                        web.MembersCanShare = webSettings.MembersCanShare;
-                    }
-
-                    if (web.DisableFlows != webSettings.DisableFlows)
-                    {
-                        web.DisableFlows = webSettings.DisableFlows;
-                    }
-
-                    if (web.DisableAppViews != webSettings.DisableAppViews)
-                    {
-                        web.DisableAppViews = webSettings.DisableAppViews;
-                    }
-
-                    if (web.HorizontalQuickLaunch != webSettings.HorizontalQuickLaunch)
-                    {
-                        web.HorizontalQuickLaunch = webSettings.HorizontalQuickLaunch;
-                    }
+                    web.SetValue(x => x.CommentsOnSitePagesDisabled, webSettings.CommentsOnSitePagesDisabled);
+                    web.SetValue(x => x.ExcludeFromOfflineClient, webSettings.ExcludeFromOfflineClient);
+                    web.SetValue(x => x.MembersCanShare, webSettings.MembersCanShare);
+                    web.SetValue(x => x.DisableFlows, webSettings.DisableFlows);
+                    web.SetValue(x => x.DisableAppViews, webSettings.DisableAppViews);
+                    web.SetValue(x => x.HorizontalQuickLaunch, webSettings.HorizontalQuickLaunch);
 
 #if !SP2019
-                    if (web.SearchScope.ToString() != webSettings.SearchScope.ToString())
+                    if (webSettings.SearchScope.HasValue && web.SearchScope.ToString() != webSettings.SearchScope.ToString())
                     {
                         web.SearchScope = (SearchScopeType)Enum.Parse(typeof(SearchScopeType), webSettings.SearchScope.ToString(), true);
                     }
 
-                    if(web.SearchBoxInNavBar.ToString() != webSettings.SearchBoxInNavBar.ToString())
+                    if(webSettings.SearchBoxInNavBar.HasValue && web.SearchBoxInNavBar.ToString() != webSettings.SearchBoxInNavBar.ToString())
                     {
                         web.SearchBoxInNavBar = (SearchBoxInNavBarType)Enum.Parse(typeof(SearchBoxInNavBarType), webSettings.SearchBoxInNavBar.ToString(), true);
                     }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/TermGroupHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/TermGroupHelper.cs
@@ -133,8 +133,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                     {
                         set.Description = parser.ParseString(modelTermSet.Description);
                     }
-                    set.IsOpenForTermCreation = modelTermSet.IsOpenForTermCreation;
-                    set.IsAvailableForTagging = modelTermSet.IsAvailableForTagging;
+                    if (modelTermSet.IsOpenForTermCreation.HasValue)
+                    {
+                        set.IsOpenForTermCreation = modelTermSet.IsOpenForTermCreation.Value;
+                    }
+                    if (modelTermSet.IsAvailableForTagging.HasValue)
+                    {
+                        set.IsAvailableForTagging = modelTermSet.IsAvailableForTagging.Value;
+                    }
                     foreach (var property in modelTermSet.Properties)
                     {
                         set.SetCustomProperty(property.Key, parser.ParseString(property.Value));
@@ -266,7 +272,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
 
             var reusedTerms = new List<ReusedTerm>();
             // If the term is a re-used term and the term is not a source term, skip for now and create later
-            if (modelTerm.IsReused && !modelTerm.IsSourceTerm)
+            
+            if (!modelTerm.IsSourceTerm)
             {
                 reusedTerms.Add(new ReusedTerm()
                 {
@@ -308,7 +315,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                 term.Owner = modelTerm.Owner;
             }
 
-            term.IsAvailableForTagging = modelTerm.IsAvailableForTagging;
+            if (modelTerm.IsAvailableForTagging.HasValue)
+            {
+                term.IsAvailableForTagging = modelTerm.IsAvailableForTagging.Value;
+            }
 
             if (modelTerm.Properties.Any() || modelTerm.Labels.Any() || modelTerm.LocalProperties.Any())
             {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/PnPObjectsMapper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/PnPObjectsMapper.cs
@@ -166,45 +166,59 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                             else
                             {
                                 object sourceValue = sp.GetValue(source);
-                                if (sourceValue != null && dp.PropertyType == typeof(string) && sp.PropertyType != typeof(string))
-                                {
-                                    // Default conversion to String
-                                    sourceValue = sourceValue.ToString();
-                                }
-                                else if (sourceValue != null && dp.PropertyType == typeof(int) && sp.PropertyType != typeof(int))
-                                {
-                                    // Default conversion to Int32
-                                    sourceValue = Int32.Parse(sourceValue.ToString());
-                                }
-                                else if (sourceValue != null && dp.PropertyType == typeof(bool) && sp.PropertyType != typeof(bool))
-                                {
-                                    // Default conversion to Boolean
-                                    sourceValue = Boolean.Parse(sourceValue.ToString());
-                                }
-                                else if (sourceValue == null && 
-                                    dp.ReflectedType.Namespace == typeof(ProvisioningTemplate).Namespace && 
-                                    dp.GetValue(destination) != null)
-                                {
-                                    // If the destination property is an in memory Domain Model property
-                                    // and it has a value, while the source property is null, we keep the
-                                    // existing value
-                                    sourceValue = dp.GetValue(destination);
-                                }
-                                else if (sourceValue != null && spSpecified != null)
+                                Type nullableDestinationType = Nullable.GetUnderlyingType(dp.PropertyType);
+                                bool isSpecified;
+                                if (spSpecified != null)
                                 {
                                     // We are processing a property of the schema, which can be nullable
-                                    bool isSpecified = (bool)spSpecified.GetValue(source);
-                                    if (!isSpecified)
+                                    isSpecified = (bool)spSpecified.GetValue(source);
+                                }
+                                else
+                                {
+                                    isSpecified = true;
+                                }
+
+                                if (isSpecified)
+                                {
+                                    if (sourceValue != null && dp.PropertyType == typeof(string) && sp.PropertyType != typeof(string))
                                     {
-                                        sourceValue = null;
+                                        // Default conversion to String
+                                        sourceValue = sourceValue.ToString();
                                     }
+                                    else if (sourceValue != null && (dp.PropertyType == typeof(int) || nullableDestinationType == typeof(int)) && sp.PropertyType != typeof(int))
+                                    {
+                                        // Default conversion to Int32
+                                        sourceValue = Int32.Parse(sourceValue.ToString());
+                                    }
+                                    else if (sourceValue != null && dp.PropertyType == typeof(bool) && sp.PropertyType != typeof(bool))
+                                    {
+                                        // Default conversion to Boolean
+                                        sourceValue = Boolean.Parse(sourceValue.ToString());
+                                    }
+                                    else if (sourceValue == null &&
+                                        dp.ReflectedType.Namespace == typeof(ProvisioningTemplate).Namespace &&
+                                        dp.GetValue(destination) != null)
+                                    {
+                                        // If the destination property is an in memory Domain Model property
+                                        // and it has a value, while the source property is null, we keep the
+                                        // existing value
+                                        sourceValue = dp.GetValue(destination);
+                                    }
+                                    else if (sourceValue != null && nullableDestinationType != null && nullableDestinationType.IsEnum)
+                                    {
+                                        sourceValue = Enum.Parse(nullableDestinationType, sourceValue.ToString(), true);
+                                    }
+                                }
+                                else
+                                {
+                                    sourceValue = null;
                                 }
                                 // We simply need to do 1:1 value mapping
                                 dp.SetValue(destination, sourceValue);
 
                                 if (dpSpecified != null)
                                 {
-                                    dpSpecified.SetValue(destination, true);
+                                    dpSpecified.SetValue(destination, sourceValue != null);
                                 }
                             }
                         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Resolvers/CalendarTypeFromSchemaToModelValueResolver.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Resolvers/CalendarTypeFromSchemaToModelValueResolver.cs
@@ -48,7 +48,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.Resolvers
                     return Microsoft.SharePoint.Client.CalendarType.UmAlQura;
                 case "None":
                 default:
-                    return Microsoft.SharePoint.Client.CalendarType.None;
+                    return null;
             }
         }
     }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Resolvers/WorkHourFromSchemaToModelValueResolver.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Resolvers/WorkHourFromSchemaToModelValueResolver.cs
@@ -65,7 +65,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.Resolvers
                 case "Item1200PM":
                     return Model.WorkHour.PM1200;
                 default:
-                    return Model.WorkHour.AM0100;
+                    return null;
             }
         }
     }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Serializers/V201705/ListInstancesSerializer.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Serializers/V201705/ListInstancesSerializer.cs
@@ -178,7 +178,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.Serializers.V20
                 resolvers.Add($"{listInstanceType}.MinorVersionLimitSpecified", new ExpressionValueResolver(() => true));
                 resolvers.Add($"{listInstanceType}.ReadSecuritySpecified", new ExpressionValueResolver((s, v) =>
                 {
-                    var value = (Int32)s.GetPublicInstancePropertyValue("ReadSecurity");
+                    var rawValue = s.GetPublicInstancePropertyValue("ReadSecurity");
+                    if (rawValue == null)
+                    {
+                        return false;
+                    }
+                    var value = (Int32)rawValue;
                     return (value == 1 || value == 2);
                 }
                 ));

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Serializers/V201909/ListInstancesSerializer.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Serializers/V201909/ListInstancesSerializer.cs
@@ -178,7 +178,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.Serializers.V20
                 resolvers.Add($"{listInstanceType}.MinorVersionLimitSpecified", new ExpressionValueResolver(() => true));
                 resolvers.Add($"{listInstanceType}.ReadSecuritySpecified", new ExpressionValueResolver((s, v) =>
                 {
-                    var value = (Int32)s.GetPublicInstancePropertyValue("ReadSecurity");
+                    var rawValue = s.GetPublicInstancePropertyValue("ReadSecurity");
+                    if (rawValue == null)
+                    {
+                        return false;
+                    }
+                    var value = (Int32)rawValue;
                     return (value == 1 || value == 2);
                 }
                 ));

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201503Formatter.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201503Formatter.cs
@@ -233,14 +233,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                     (from list in template.Lists
                      select new V201503.ListInstance
                      {
-                         ContentTypesEnabled = list.ContentTypesEnabled,
+                         ContentTypesEnabled = list.ContentTypesEnabled.GetValueOrDefault(),
                          Description = list.Description,
                          DocumentTemplate = list.DocumentTemplate,
-                         EnableVersioning = list.EnableVersioning,
-                         Hidden = list.Hidden,
-                         MinorVersionLimit = list.MinorVersionLimit,
-                         MaxVersionLimit = list.MaxVersionLimit,
-                         OnQuickLaunch = list.OnQuickLaunch,
+                         EnableVersioning = list.EnableVersioning.GetValueOrDefault(),
+                         Hidden = list.Hidden.GetValueOrDefault(),
+                         MinorVersionLimit = list.MinorVersionLimit.GetValueOrDefault(),
+                         MaxVersionLimit = list.MaxVersionLimit.GetValueOrDefault(),
+                         OnQuickLaunch = list.OnQuickLaunch.GetValueOrDefault(),
                          RemoveDefaultContentType = list.RemoveExistingContentTypes,
                          TemplateType = list.TemplateType,
                          Title = list.Title,

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201505Formatter.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201505Formatter.cs
@@ -120,7 +120,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                      {
                          Key = bag.Key,
                          Value = bag.Value,
-                         Indexed = bag.Indexed
+                         Indexed = bag.Indexed.GetValueOrDefault()
                      }).ToArray();
             }
             else
@@ -221,17 +221,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                                            Description = ct.Description,
                                            Group = ct.Group,
                                            Name = ct.Name,
-                                           Sealed = ct.Sealed,
-                                           Hidden = ct.Hidden,
-                                           ReadOnly = ct.ReadOnly,
+                                           Sealed = ct.Sealed.GetValueOrDefault(),
+                                           Hidden = ct.Hidden.GetValueOrDefault(),
+                                           ReadOnly = ct.ReadOnly.GetValueOrDefault(),
                                            FieldRefs = ct.FieldRefs.Count > 0 ?
                     (from fieldRef in ct.FieldRefs
                      select new V201505.ContentTypeFieldRef
                      {
                          Name = fieldRef.Name,
                          ID = fieldRef.Id.ToString(),
-                         Hidden = fieldRef.Hidden,
-                         Required = fieldRef.Required
+                         Hidden = fieldRef.Hidden.GetValueOrDefault(),
+                         Required = fieldRef.Required.GetValueOrDefault()
                      }).ToArray() : null,
                                        }).ToArray();
 
@@ -250,21 +250,21 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                     (from list in template.Lists
                      select new V201505.ListInstance
                      {
-                         ContentTypesEnabled = list.ContentTypesEnabled,
+                         ContentTypesEnabled = list.ContentTypesEnabled.GetValueOrDefault(),
                          Description = list.Description,
                          DocumentTemplate = list.DocumentTemplate,
-                         EnableVersioning = list.EnableVersioning,
-                         EnableMinorVersions = list.EnableMinorVersions,
-                         EnableModeration = list.EnableModeration,
-                         DraftVersionVisibility = list.DraftVersionVisibility,
-                         Hidden = list.Hidden,
-                         MinorVersionLimit = list.MinorVersionLimit,
+                         EnableVersioning = list.EnableVersioning.GetValueOrDefault(),
+                         EnableMinorVersions = list.EnableMinorVersions.GetValueOrDefault(),
+                         EnableModeration = list.EnableModeration.GetValueOrDefault(),
+                         DraftVersionVisibility = list.DraftVersionVisibility.GetValueOrDefault(),
+                         Hidden = list.Hidden.GetValueOrDefault(),
+                         MinorVersionLimit = list.MinorVersionLimit.GetValueOrDefault(),
                          MinorVersionLimitSpecified = true,
-                         MaxVersionLimit = list.MaxVersionLimit,
+                         MaxVersionLimit = list.MaxVersionLimit.GetValueOrDefault(),
                          MaxVersionLimitSpecified = true,
-                         OnQuickLaunch = list.OnQuickLaunch,
-                         EnableAttachments = list.EnableAttachments,
-                         EnableFolderCreation = list.EnableFolderCreation,
+                         OnQuickLaunch = list.OnQuickLaunch.GetValueOrDefault(),
+                         EnableAttachments = list.EnableAttachments.GetValueOrDefault(true),
+                         EnableFolderCreation = list.EnableFolderCreation.GetValueOrDefault(true),
                          RemoveExistingContentTypes = list.RemoveExistingContentTypes,
                          TemplateFeatureID = list.TemplateFeatureID != Guid.Empty ? list.TemplateFeatureID.ToString() : null,
                          TemplateType = list.TemplateType,
@@ -298,8 +298,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                           {
                               Name = fieldRef.Name,
                               DisplayName = fieldRef.DisplayName,
-                              Hidden = fieldRef.Hidden,
-                              Required = fieldRef.Required,
+                              Hidden = fieldRef.Hidden.GetValueOrDefault(),
+                              Required = fieldRef.Required.GetValueOrDefault(),
                               ID = fieldRef.Id.ToString(),
                           }).ToArray() : null,
                          DataRows = list.DataRows.Count > 0 ?
@@ -546,8 +546,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                             {
                                 ID = termSet.Id.ToString(),
                                 Name = termSet.Name,
-                                IsAvailableForTagging = termSet.IsAvailableForTagging,
-                                IsOpenForTermCreation = termSet.IsOpenForTermCreation,
+                                IsAvailableForTagging = termSet.IsAvailableForTagging.GetValueOrDefault(true),
+                                IsOpenForTermCreation = termSet.IsOpenForTermCreation.GetValueOrDefault(false),
                                 Description = termSet.Description,
                                 Language = termSet.Language.HasValue ? termSet.Language.Value : 0,
                                 LanguageSpecified = termSet.Language.HasValue,
@@ -1128,7 +1128,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                     Owner = term.Owner,
                     LanguageSpecified = term.Language.HasValue,
                     Language = term.Language.HasValue ? term.Language.Value : 1033,
-                    IsAvailableForTagging = term.IsAvailableForTagging,
+                    IsAvailableForTagging = term.IsAvailableForTagging.GetValueOrDefault(true),
                     CustomSortOrder = term.CustomSortOrder,
                     Terms = term.Terms.Count > 0 ? new TermTerms { Items = term.Terms.FromModelTermsToSchemaTermsV201505() } : null,
                     CustomProperties = term.Properties.Count > 0 ?

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201508Formatter.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201508Formatter.cs
@@ -139,7 +139,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                      {
                          Key = bag.Key,
                          Value = bag.Value,
-                         Indexed = bag.Indexed,
+                         Indexed = bag.Indexed.GetValueOrDefault(),
                          Overwrite = bag.Overwrite,
                          OverwriteSpecified = true,
                      }).ToArray();
@@ -157,30 +157,30 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
             {
                 result.RegionalSettings = new V201508.RegionalSettings()
                 {
-                    AdjustHijriDays = template.RegionalSettings.AdjustHijriDays,
+                    AdjustHijriDays = template.RegionalSettings.AdjustHijriDays.GetValueOrDefault(),
                     AdjustHijriDaysSpecified = true,
-                    AlternateCalendarType = template.RegionalSettings.AlternateCalendarType.FromTemplateToSchemaCalendarTypeV201508(),
+                    AlternateCalendarType = template.RegionalSettings.AlternateCalendarType.GetValueOrDefault(Microsoft.SharePoint.Client.CalendarType.None).FromTemplateToSchemaCalendarTypeV201508(),
                     AlternateCalendarTypeSpecified = true,
-                    CalendarType = template.RegionalSettings.CalendarType.FromTemplateToSchemaCalendarTypeV201508(),
+                    CalendarType = template.RegionalSettings.CalendarType.GetValueOrDefault(Microsoft.SharePoint.Client.CalendarType.None).FromTemplateToSchemaCalendarTypeV201508(),
                     CalendarTypeSpecified = true,
-                    Collation = template.RegionalSettings.Collation,
+                    Collation = template.RegionalSettings.Collation.GetValueOrDefault(),
                     CollationSpecified = true,
-                    FirstDayOfWeek = (V201508.DayOfWeek)Enum.Parse(typeof(V201508.DayOfWeek), template.RegionalSettings.FirstDayOfWeek.ToString()),
+                    FirstDayOfWeek = (V201508.DayOfWeek)Enum.Parse(typeof(V201508.DayOfWeek), template.RegionalSettings.FirstDayOfWeek.HasValue? template.RegionalSettings.FirstDayOfWeek.Value.ToString() : System.DayOfWeek.Sunday.ToString()),
                     FirstDayOfWeekSpecified = true,
-                    FirstWeekOfYear = template.RegionalSettings.FirstWeekOfYear,
+                    FirstWeekOfYear = template.RegionalSettings.FirstWeekOfYear.GetValueOrDefault(),
                     FirstWeekOfYearSpecified = true,
-                    LocaleId = template.RegionalSettings.LocaleId,
+                    LocaleId = template.RegionalSettings.LocaleId.GetValueOrDefault(1033),
                     LocaleIdSpecified = true,
-                    ShowWeeks = template.RegionalSettings.ShowWeeks,
+                    ShowWeeks = template.RegionalSettings.ShowWeeks.GetValueOrDefault(),
                     ShowWeeksSpecified = true,
-                    Time24 = template.RegionalSettings.Time24,
+                    Time24 = template.RegionalSettings.Time24.GetValueOrDefault(),
                     Time24Specified = true,
-                    TimeZone = template.RegionalSettings.TimeZone.ToString(),
-                    WorkDayEndHour = template.RegionalSettings.WorkDayEndHour.FromTemplateToSchemaWorkHourV201508(),
+                    TimeZone = template.RegionalSettings.TimeZone.GetValueOrDefault().ToString(),
+                    WorkDayEndHour = template.RegionalSettings.WorkDayEndHour.GetValueOrDefault(Model.WorkHour.PM0600).FromTemplateToSchemaWorkHourV201508(),
                     WorkDayEndHourSpecified = true,
-                    WorkDays = template.RegionalSettings.WorkDays,
+                    WorkDays = template.RegionalSettings.WorkDays.GetValueOrDefault(5),
                     WorkDaysSpecified = true,
-                    WorkDayStartHour = template.RegionalSettings.WorkDayStartHour.FromTemplateToSchemaWorkHourV201508(),
+                    WorkDayStartHour = template.RegionalSettings.WorkDayStartHour.GetValueOrDefault(Model.WorkHour.AM0900).FromTemplateToSchemaWorkHourV201508(),
                     WorkDayStartHourSpecified = true,
                 };
             }
@@ -393,17 +393,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                          Description = ct.Description,
                          Group = ct.Group,
                          Name = ct.Name,
-                         Sealed = ct.Sealed,
-                         Hidden =  ct.Hidden,
-                         ReadOnly = ct.ReadOnly,
+                         Sealed = ct.Sealed.GetValueOrDefault(),
+                         Hidden =  ct.Hidden.GetValueOrDefault(),
+                         ReadOnly = ct.ReadOnly.GetValueOrDefault(),
                          FieldRefs = ct.FieldRefs.Count > 0 ?
                          (from fieldRef in ct.FieldRefs
                           select new V201508.ContentTypeFieldRef
                           {
                               Name = fieldRef.Name,
                               ID = fieldRef.Id.ToString(),
-                              Hidden = fieldRef.Hidden,
-                              Required = fieldRef.Required
+                              Hidden = fieldRef.Hidden.GetValueOrDefault(),
+                              Required = fieldRef.Required.GetValueOrDefault()
                           }).ToArray() : null,
                          DocumentSetTemplate = ct.DocumentSetTemplate != null ?
                              new V201508.DocumentSetTemplate
@@ -457,22 +457,22 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                     (from list in template.Lists
                      select new V201508.ListInstance
                      {
-                         ContentTypesEnabled = list.ContentTypesEnabled,
+                         ContentTypesEnabled = list.ContentTypesEnabled.GetValueOrDefault(),
                          Description = list.Description,
                          DocumentTemplate = list.DocumentTemplate,
-                         EnableVersioning = list.EnableVersioning,
-                         EnableMinorVersions = list.EnableMinorVersions,
-                         EnableModeration = list.EnableModeration,
-                         DraftVersionVisibility = list.DraftVersionVisibility,
+                         EnableVersioning = list.EnableVersioning.GetValueOrDefault(),
+                         EnableMinorVersions = list.EnableMinorVersions.GetValueOrDefault(),
+                         EnableModeration = list.EnableModeration.GetValueOrDefault(),
+                         DraftVersionVisibility = list.DraftVersionVisibility.GetValueOrDefault(),
                          DraftVersionVisibilitySpecified = true,
-                         Hidden = list.Hidden,
-                         MinorVersionLimit = list.MinorVersionLimit,
+                         Hidden = list.Hidden.GetValueOrDefault(),
+                         MinorVersionLimit = list.MinorVersionLimit.GetValueOrDefault(),
                          MinorVersionLimitSpecified = true,
-                         MaxVersionLimit = list.MaxVersionLimit,
+                         MaxVersionLimit = list.MaxVersionLimit.GetValueOrDefault(),
                          MaxVersionLimitSpecified = true,
-                         OnQuickLaunch = list.OnQuickLaunch,
-                         EnableAttachments = list.EnableAttachments,
-                         EnableFolderCreation = list.EnableFolderCreation,
+                         OnQuickLaunch = list.OnQuickLaunch.GetValueOrDefault(),
+                         EnableAttachments = list.EnableAttachments.GetValueOrDefault(true),
+                         EnableFolderCreation = list.EnableFolderCreation.GetValueOrDefault(true),
                          RemoveExistingContentTypes = list.RemoveExistingContentTypes,
                          TemplateFeatureID = list.TemplateFeatureID != Guid.Empty ? list.TemplateFeatureID.ToString() : null,
                          TemplateType = list.TemplateType,
@@ -509,8 +509,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                           {
                               Name = fieldRef.Name,
                               DisplayName = fieldRef.DisplayName,
-                              Hidden = fieldRef.Hidden,
-                              Required = fieldRef.Required,
+                              Hidden = fieldRef.Hidden.GetValueOrDefault(),
+                              Required = fieldRef.Required.GetValueOrDefault(),
                               ID = fieldRef.Id.ToString(),
                           }).ToArray() : null,
                          DataRows = list.DataRows.Count > 0 ?
@@ -781,8 +781,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                             {
                                 ID = termSet.Id.ToString(),
                                 Name = termSet.Name,
-                                IsAvailableForTagging = termSet.IsAvailableForTagging,
-                                IsOpenForTermCreation = termSet.IsOpenForTermCreation,
+                                IsAvailableForTagging = termSet.IsAvailableForTagging.GetValueOrDefault(true),
+                                IsOpenForTermCreation = termSet.IsOpenForTermCreation.GetValueOrDefault(false),
                                 Description = termSet.Description,
                                 Language = termSet.Language.HasValue ? termSet.Language.Value : 0,
                                 LanguageSpecified = termSet.Language.HasValue,
@@ -1814,7 +1814,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                     Owner = term.Owner,
                     LanguageSpecified = term.Language.HasValue,
                     Language = term.Language.HasValue ? term.Language.Value : 1033,
-                    IsAvailableForTagging = term.IsAvailableForTagging,
+                    IsAvailableForTagging = term.IsAvailableForTagging.GetValueOrDefault(true),
                     CustomSortOrder = term.CustomSortOrder,
                     Terms = term.Terms.Count > 0 ? new V201508.TermTerms { Items = term.Terms.FromModelTermsToSchemaTermsV201508() } : null,
                     CustomProperties = term.Properties.Count > 0 ?

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201512Formatter.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201512Formatter.cs
@@ -161,7 +161,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                      {
                          Key = bag.Key,
                          Value = bag.Value,
-                         Indexed = bag.Indexed,
+                         Indexed = bag.Indexed.GetValueOrDefault(),
                          Overwrite = bag.Overwrite,
                          OverwriteSpecified = true,
                      }).ToArray();
@@ -179,7 +179,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
             {
                 result.WebSettings = new V201512.WebSettings
                 {
-                    NoCrawl = template.WebSettings.NoCrawl,
+                    NoCrawl = template.WebSettings.NoCrawl.GetValueOrDefault(),
                     NoCrawlSpecified = true,
                     RequestAccessEmail = template.WebSettings.RequestAccessEmail,
                     Title = template.WebSettings.Title,
@@ -200,30 +200,30 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
             {
                 result.RegionalSettings = new V201512.RegionalSettings()
                 {
-                    AdjustHijriDays = template.RegionalSettings.AdjustHijriDays,
+                    AdjustHijriDays = template.RegionalSettings.AdjustHijriDays.GetValueOrDefault(),
                     AdjustHijriDaysSpecified = true,
-                    AlternateCalendarType = template.RegionalSettings.AlternateCalendarType.FromTemplateToSchemaCalendarTypeV201512(),
+                    AlternateCalendarType = template.RegionalSettings.AlternateCalendarType.GetValueOrDefault(Microsoft.SharePoint.Client.CalendarType.None).FromTemplateToSchemaCalendarTypeV201512(),
                     AlternateCalendarTypeSpecified = true,
-                    CalendarType = template.RegionalSettings.CalendarType.FromTemplateToSchemaCalendarTypeV201512(),
+                    CalendarType = template.RegionalSettings.CalendarType.GetValueOrDefault(Microsoft.SharePoint.Client.CalendarType.None).FromTemplateToSchemaCalendarTypeV201512(),
                     CalendarTypeSpecified = true,
-                    Collation = template.RegionalSettings.Collation,
+                    Collation = template.RegionalSettings.Collation.GetValueOrDefault(),
                     CollationSpecified = true,
-                    FirstDayOfWeek = (V201512.DayOfWeek)Enum.Parse(typeof(V201512.DayOfWeek), template.RegionalSettings.FirstDayOfWeek.ToString()),
+                    FirstDayOfWeek = (V201512.DayOfWeek)Enum.Parse(typeof(V201508.DayOfWeek), template.RegionalSettings.FirstDayOfWeek.HasValue ? template.RegionalSettings.FirstDayOfWeek.Value.ToString() : System.DayOfWeek.Sunday.ToString()),
                     FirstDayOfWeekSpecified = true,
-                    FirstWeekOfYear = template.RegionalSettings.FirstWeekOfYear,
+                    FirstWeekOfYear = template.RegionalSettings.FirstWeekOfYear.GetValueOrDefault(),
                     FirstWeekOfYearSpecified = true,
-                    LocaleId = template.RegionalSettings.LocaleId,
+                    LocaleId = template.RegionalSettings.LocaleId.GetValueOrDefault(1033),
                     LocaleIdSpecified = true,
-                    ShowWeeks = template.RegionalSettings.ShowWeeks,
+                    ShowWeeks = template.RegionalSettings.ShowWeeks.GetValueOrDefault(),
                     ShowWeeksSpecified = true,
-                    Time24 = template.RegionalSettings.Time24,
+                    Time24 = template.RegionalSettings.Time24.GetValueOrDefault(),
                     Time24Specified = true,
-                    TimeZone = template.RegionalSettings.TimeZone.ToString(),
-                    WorkDayEndHour = template.RegionalSettings.WorkDayEndHour.FromTemplateToSchemaWorkHourV201512(),
+                    TimeZone = template.RegionalSettings.TimeZone.GetValueOrDefault().ToString(),
+                    WorkDayEndHour = template.RegionalSettings.WorkDayEndHour.GetValueOrDefault(Model.WorkHour.PM0600).FromTemplateToSchemaWorkHourV201512(),
                     WorkDayEndHourSpecified = true,
-                    WorkDays = template.RegionalSettings.WorkDays,
+                    WorkDays = template.RegionalSettings.WorkDays.GetValueOrDefault(5),
                     WorkDaysSpecified = true,
-                    WorkDayStartHour = template.RegionalSettings.WorkDayStartHour.FromTemplateToSchemaWorkHourV201512(),
+                    WorkDayStartHour = template.RegionalSettings.WorkDayStartHour.GetValueOrDefault(Model.WorkHour.AM0900).FromTemplateToSchemaWorkHourV201512(),
                     WorkDayStartHourSpecified = true,
                 };
             }
@@ -447,17 +447,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                          Description = ct.Description,
                          Group = ct.Group,
                          Name = ct.Name,
-                         Sealed = ct.Sealed,
-                         Hidden = ct.Hidden,
-                         ReadOnly = ct.ReadOnly,
+                         Sealed = ct.Sealed.GetValueOrDefault(),
+                         Hidden = ct.Hidden.GetValueOrDefault(),
+                         ReadOnly = ct.ReadOnly.GetValueOrDefault(),
                          FieldRefs = ct.FieldRefs.Count > 0 ?
                          (from fieldRef in ct.FieldRefs
                           select new V201512.ContentTypeFieldRef
                           {
                               Name = fieldRef.Name,
                               ID = fieldRef.Id.ToString(),
-                              Hidden = fieldRef.Hidden,
-                              Required = fieldRef.Required
+                              Hidden = fieldRef.Hidden.GetValueOrDefault(),
+                              Required = fieldRef.Required.GetValueOrDefault()
                           }).ToArray() : null,
                          DocumentTemplate = !String.IsNullOrEmpty(ct.DocumentTemplate) ? new ContentTypeDocumentTemplate { TargetName = ct.DocumentTemplate } : null,
                          DocumentSetTemplate = ct.DocumentSetTemplate != null ?
@@ -512,22 +512,22 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                     (from list in template.Lists
                      select new V201512.ListInstance
                      {
-                         ContentTypesEnabled = list.ContentTypesEnabled,
+                         ContentTypesEnabled = list.ContentTypesEnabled.GetValueOrDefault(),
                          Description = list.Description,
                          DocumentTemplate = list.DocumentTemplate,
-                         EnableVersioning = list.EnableVersioning,
-                         EnableMinorVersions = list.EnableMinorVersions,
-                         EnableModeration = list.EnableModeration,
-                         DraftVersionVisibility = list.DraftVersionVisibility,
+                         EnableVersioning = list.EnableVersioning.GetValueOrDefault(),
+                         EnableMinorVersions = list.EnableMinorVersions.GetValueOrDefault(),
+                         EnableModeration = list.EnableModeration.GetValueOrDefault(),
+                         DraftVersionVisibility = list.DraftVersionVisibility.GetValueOrDefault(),
                          DraftVersionVisibilitySpecified = true,
-                         Hidden = list.Hidden,
-                         MinorVersionLimit = list.MinorVersionLimit,
+                         Hidden = list.Hidden.GetValueOrDefault(),
+                         MinorVersionLimit = list.MinorVersionLimit.GetValueOrDefault(),
                          MinorVersionLimitSpecified = true,
-                         MaxVersionLimit = list.MaxVersionLimit,
+                         MaxVersionLimit = list.MaxVersionLimit.GetValueOrDefault(),
                          MaxVersionLimitSpecified = true,
-                         OnQuickLaunch = list.OnQuickLaunch,
-                         EnableAttachments = list.EnableAttachments,
-                         EnableFolderCreation = list.EnableFolderCreation,
+                         OnQuickLaunch = list.OnQuickLaunch.GetValueOrDefault(),
+                         EnableAttachments = list.EnableAttachments.GetValueOrDefault(true),
+                         EnableFolderCreation = list.EnableFolderCreation.GetValueOrDefault(true),
                          RemoveExistingContentTypes = list.RemoveExistingContentTypes,
                          TemplateFeatureID = list.TemplateFeatureID != Guid.Empty ? list.TemplateFeatureID.ToString() : null,
                          TemplateType = list.TemplateType,
@@ -564,8 +564,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                           {
                               Name = fieldRef.Name,
                               DisplayName = fieldRef.DisplayName,
-                              Hidden = fieldRef.Hidden,
-                              Required = fieldRef.Required,
+                              Hidden = fieldRef.Hidden.GetValueOrDefault(),
+                              Required = fieldRef.Required.GetValueOrDefault(),
                               ID = fieldRef.Id.ToString(),
                           }).ToArray() : null,
                          DataRows = list.DataRows.Count > 0 ?
@@ -851,8 +851,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                             {
                                 ID = termSet.Id != Guid.Empty ? termSet.Id.ToString() : null,
                                 Name = termSet.Name,
-                                IsAvailableForTagging = termSet.IsAvailableForTagging,
-                                IsOpenForTermCreation = termSet.IsOpenForTermCreation,
+                                IsAvailableForTagging = termSet.IsAvailableForTagging.GetValueOrDefault(true),
+                                IsOpenForTermCreation = termSet.IsOpenForTermCreation.GetValueOrDefault(false),
                                 Description = termSet.Description,
                                 Language = termSet.Language.HasValue ? termSet.Language.Value : 0,
                                 LanguageSpecified = termSet.Language.HasValue,
@@ -1921,7 +1921,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                     Owner = term.Owner,
                     LanguageSpecified = term.Language.HasValue,
                     Language = term.Language.HasValue ? term.Language.Value : 1033,
-                    IsAvailableForTagging = term.IsAvailableForTagging,
+                    IsAvailableForTagging = term.IsAvailableForTagging.GetValueOrDefault(true),
                     CustomSortOrder = term.CustomSortOrder,
                     Terms = term.Terms.Count > 0 ? new V201512.TermTerms { Items = term.Terms.FromModelTermsToSchemaTermsV201512() } : null,
                     CustomProperties = term.Properties.Count > 0 ?

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201605Formatter.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201605Formatter.cs
@@ -162,7 +162,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                      {
                          Key = bag.Key,
                          Value = bag.Value,
-                         Indexed = bag.Indexed,
+                         Indexed = bag.Indexed.GetValueOrDefault(),
                          Overwrite = bag.Overwrite,
                          OverwriteSpecified = true,
                      }).ToArray();
@@ -180,7 +180,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
             {
                 result.WebSettings = new V201605.WebSettings
                 {
-                    NoCrawl = template.WebSettings.NoCrawl,
+                    NoCrawl = template.WebSettings.NoCrawl.GetValueOrDefault(),
                     NoCrawlSpecified = true,
                     RequestAccessEmail = template.WebSettings.RequestAccessEmail,
                     Title = template.WebSettings.Title,
@@ -201,30 +201,30 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
             {
                 result.RegionalSettings = new V201605.RegionalSettings()
                 {
-                    AdjustHijriDays = template.RegionalSettings.AdjustHijriDays,
+                    AdjustHijriDays = template.RegionalSettings.AdjustHijriDays.GetValueOrDefault(),
                     AdjustHijriDaysSpecified = true,
-                    AlternateCalendarType = template.RegionalSettings.AlternateCalendarType.FromTemplateToSchemaCalendarTypeV201605(),
+                    AlternateCalendarType = template.RegionalSettings.AlternateCalendarType.GetValueOrDefault(Microsoft.SharePoint.Client.CalendarType.None).FromTemplateToSchemaCalendarTypeV201605(),
                     AlternateCalendarTypeSpecified = true,
-                    CalendarType = template.RegionalSettings.CalendarType.FromTemplateToSchemaCalendarTypeV201605(),
+                    CalendarType = template.RegionalSettings.CalendarType.GetValueOrDefault(Microsoft.SharePoint.Client.CalendarType.None).FromTemplateToSchemaCalendarTypeV201605(),
                     CalendarTypeSpecified = true,
-                    Collation = template.RegionalSettings.Collation,
+                    Collation = template.RegionalSettings.Collation.GetValueOrDefault(),
                     CollationSpecified = true,
-                    FirstDayOfWeek = (V201605.DayOfWeek)Enum.Parse(typeof(V201605.DayOfWeek), template.RegionalSettings.FirstDayOfWeek.ToString()),
+                    FirstDayOfWeek = (V201605.DayOfWeek)Enum.Parse(typeof(V201508.DayOfWeek), template.RegionalSettings.FirstDayOfWeek.HasValue ? template.RegionalSettings.FirstDayOfWeek.Value.ToString() : System.DayOfWeek.Sunday.ToString()),
                     FirstDayOfWeekSpecified = true,
-                    FirstWeekOfYear = template.RegionalSettings.FirstWeekOfYear,
+                    FirstWeekOfYear = template.RegionalSettings.FirstWeekOfYear.GetValueOrDefault(),
                     FirstWeekOfYearSpecified = true,
-                    LocaleId = template.RegionalSettings.LocaleId,
+                    LocaleId = template.RegionalSettings.LocaleId.GetValueOrDefault(1033),
                     LocaleIdSpecified = true,
-                    ShowWeeks = template.RegionalSettings.ShowWeeks,
+                    ShowWeeks = template.RegionalSettings.ShowWeeks.GetValueOrDefault(),
                     ShowWeeksSpecified = true,
-                    Time24 = template.RegionalSettings.Time24,
+                    Time24 = template.RegionalSettings.Time24.GetValueOrDefault(),
                     Time24Specified = true,
-                    TimeZone = template.RegionalSettings.TimeZone.ToString(),
-                    WorkDayEndHour = template.RegionalSettings.WorkDayEndHour.FromTemplateToSchemaWorkHourV201605(),
+                    TimeZone = template.RegionalSettings.TimeZone.GetValueOrDefault().ToString(),
+                    WorkDayEndHour = template.RegionalSettings.WorkDayEndHour.GetValueOrDefault(Model.WorkHour.PM0600).FromTemplateToSchemaWorkHourV201605(),
                     WorkDayEndHourSpecified = true,
-                    WorkDays = template.RegionalSettings.WorkDays,
+                    WorkDays = template.RegionalSettings.WorkDays.GetValueOrDefault(5),
                     WorkDaysSpecified = true,
-                    WorkDayStartHour = template.RegionalSettings.WorkDayStartHour.FromTemplateToSchemaWorkHourV201605(),
+                    WorkDayStartHour = template.RegionalSettings.WorkDayStartHour.GetValueOrDefault(Model.WorkHour.AM0900).FromTemplateToSchemaWorkHourV201605(),
                     WorkDayStartHourSpecified = true,
                 };
             }
@@ -506,17 +506,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                          Description = ct.Description,
                          Group = ct.Group,
                          Name = ct.Name,
-                         Hidden = ct.Hidden,
-                         Sealed = ct.Sealed,
-                         ReadOnly = ct.ReadOnly,
+                         Hidden = ct.Hidden.GetValueOrDefault(),
+                         Sealed = ct.Sealed.GetValueOrDefault(),
+                         ReadOnly = ct.ReadOnly.GetValueOrDefault(),
                          FieldRefs = ct.FieldRefs.Count > 0 ?
                          (from fieldRef in ct.FieldRefs
                           select new V201605.ContentTypeFieldRef
                           {
                               Name = fieldRef.Name,
                               ID = fieldRef.Id.ToString(),
-                              Hidden = fieldRef.Hidden,
-                              Required = fieldRef.Required
+                              Hidden = fieldRef.Hidden.GetValueOrDefault(),
+                              Required = fieldRef.Required.GetValueOrDefault()
                           }).ToArray() : null,
                          DocumentTemplate = !String.IsNullOrEmpty(ct.DocumentTemplate) ? new ContentTypeDocumentTemplate { TargetName = ct.DocumentTemplate } : null,
                          DocumentSetTemplate = ct.DocumentSetTemplate != null ?
@@ -571,23 +571,23 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                     (from list in template.Lists
                      select new V201605.ListInstance
                      {
-                         ContentTypesEnabled = list.ContentTypesEnabled,
+                         ContentTypesEnabled = list.ContentTypesEnabled.GetValueOrDefault(),
                          Description = list.Description,
                          DocumentTemplate = list.DocumentTemplate,
-                         EnableVersioning = list.EnableVersioning,
-                         EnableMinorVersions = list.EnableMinorVersions,
-                         EnableModeration = list.EnableModeration,
-                         DraftVersionVisibility = list.DraftVersionVisibility,
+                         EnableVersioning = list.EnableVersioning.GetValueOrDefault(),
+                         EnableMinorVersions = list.EnableMinorVersions.GetValueOrDefault(),
+                         EnableModeration = list.EnableModeration.GetValueOrDefault(),
+                         DraftVersionVisibility = list.DraftVersionVisibility.GetValueOrDefault(),
                          DraftVersionVisibilitySpecified = true,
-                         Hidden = list.Hidden,
-                         MinorVersionLimit = list.MinorVersionLimit,
+                         Hidden = list.Hidden.GetValueOrDefault(),
+                         MinorVersionLimit = list.MinorVersionLimit.GetValueOrDefault(),
                          MinorVersionLimitSpecified = true,
-                         MaxVersionLimit = list.MaxVersionLimit,
+                         MaxVersionLimit = list.MaxVersionLimit.GetValueOrDefault(),
                          MaxVersionLimitSpecified = true,
-                         OnQuickLaunch = list.OnQuickLaunch,
-                         EnableAttachments = list.EnableAttachments,
-                         EnableFolderCreation = list.EnableFolderCreation,
-                         ForceCheckout = list.ForceCheckout,
+                         OnQuickLaunch = list.OnQuickLaunch.GetValueOrDefault(),
+                         EnableAttachments = list.EnableAttachments.GetValueOrDefault(true),
+                         EnableFolderCreation = list.EnableFolderCreation.GetValueOrDefault(true),
+                         ForceCheckout = list.ForceCheckout.GetValueOrDefault(),
                          RemoveExistingContentTypes = list.RemoveExistingContentTypes,
                          TemplateFeatureID = list.TemplateFeatureID != Guid.Empty ? list.TemplateFeatureID.ToString() : null,
                          TemplateType = list.TemplateType,
@@ -625,8 +625,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                           {
                               Name = fieldRef.Name,
                               DisplayName = fieldRef.DisplayName,
-                              Hidden = fieldRef.Hidden,
-                              Required = fieldRef.Required,
+                              Hidden = fieldRef.Hidden.GetValueOrDefault(),
+                              Required = fieldRef.Required.GetValueOrDefault(),
                               ID = fieldRef.Id.ToString(),
                           }).ToArray() : null,
                          DataRows = list.DataRows.Count > 0 ?
@@ -949,8 +949,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                             {
                                 ID = termSet.Id != Guid.Empty ? termSet.Id.ToString() : null,
                                 Name = termSet.Name,
-                                IsAvailableForTagging = termSet.IsAvailableForTagging,
-                                IsOpenForTermCreation = termSet.IsOpenForTermCreation,
+                                IsAvailableForTagging = termSet.IsAvailableForTagging.GetValueOrDefault(true),
+                                IsOpenForTermCreation = termSet.IsOpenForTermCreation.GetValueOrDefault(false),
                                 Description = termSet.Description,
                                 Language = termSet.Language.HasValue ? termSet.Language.Value : 0,
                                 LanguageSpecified = termSet.Language.HasValue,
@@ -2163,7 +2163,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                     Owner = term.Owner,
                     LanguageSpecified = term.Language.HasValue,
                     Language = term.Language.HasValue ? term.Language.Value : 1033,
-                    IsAvailableForTagging = term.IsAvailableForTagging,
+                    IsAvailableForTagging = term.IsAvailableForTagging.GetValueOrDefault(true),
                     IsDeprecated = term.IsDeprecated,
                     IsReused = term.IsReused,
                     IsSourceTerm = term.IsSourceTerm,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes?
| New feature?    | no?
| New sample?      | no?
| Related issues?  | #2413 

#### What's in this Pull Request?

Enables provisioning engine to skip setting values where optional values are not specified in the template. Previous implementation would overwrite data even if it was not specified in the template. This makes it difficult or impossible to push out changes to existing sites using the provisioning engine.

There are also related changes in PR [#466](https://github.com/SharePoint/PnP-Provisioning-Schema/pull/466) for the provisioning schema. This is not required to be in place for this PR, but it removes the default value for many of the properties and makes some properties optional.