### PR TITLE
Allow to specify a custom Tenant Theme during provisioning

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTheme.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTheme.cs
@@ -9,6 +9,7 @@ using OfficeDevPnP.Core.Utilities.Themes;
 using OfficeDevPnP.Core.Enums;
 using Newtonsoft.Json;
 using Microsoft.Online.SharePoint.TenantAdministration;
+using OfficeDevPnP.Core.Utilities;
 #if !ONPREMISES
 using static OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities.TenantHelper;
 #endif
@@ -46,6 +47,16 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         var parsedPalette = parser.ParseString(template.Theme.Palette);
 
                         ThemeManager.ApplyTheme(web, parsedPalette, template.Theme.Name ?? parsedPalette);
+                    }
+                    else
+                    {
+                        var tenantUrl = web.GetTenantAdministrationUrl();
+                        using (var tenantContext = web.Context.Clone(tenantUrl))
+                        {
+                            var tenant = new Tenant(tenantContext);
+                            tenant.SetWebTheme(parsedName, web.Url);
+                            tenant.Context.ExecuteQueryRetry();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | none

#### What's in this Pull Request?

Applying a template with a Theme already deployed Tenant Wide by using <pnp:Theme> element currently doesn't work as is simply ignored.
This PR fixes the issue by calling Tenant.SetWebTheme() with the specified Theme name as last step when processing the <pnp:Theme> element.

Template example:
```xml
<?xml version="1.0"?>
<pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2019/09/ProvisioningSchema">
  <pnp:Preferences Generator="OfficeDevPnP.Core, Version=3.15.1911.0, Culture=neutral, PublicKeyToken=5e633289e95c321a" />
  <pnp:Templates ID="CONTAINER-TEMPLATE-79C6C23772AF477A8C63A3FB31715760">
    <pnp:ProvisioningTemplate ID="TEMPLATE-79C6C23772AF477A8C63A3FB31715760" Version="1" BaseSiteTemplate="GROUP#0" Scope="RootSite">
      <pnp:Theme Name="CustomTenantTemplate" />
    </pnp:ProvisioningTemplate>
  </pnp:Templates>
</pnp:Provisioning>
```

You can compare the different behavior before and after by calling Apply-PnPProvisioningTemplate with the template above.