### PR TITLE
Feature: Added retry mechanism to handle team creation replication delays

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Graph/UnifiedGroupsUtility.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Graph/UnifiedGroupsUtility.cs
@@ -1182,7 +1182,7 @@ namespace OfficeDevPnP.Core.Framework.Graph
             {
                 await Task.Run(() =>
                 {
-                    HttpHelper.MakePutRequestForString(createTeamEndPoint, new { }, "application/json", accessToken, retryCount: 3, delay:10000);
+                    HttpHelper.MakePutRequest(createTeamEndPoint, new { }, "application/json", accessToken, retryCount: 3, delay:10000);
                 });
             }
             catch (ServiceException ex)

--- a/Core/OfficeDevPnP.Core/Framework/Graph/UnifiedGroupsUtility.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Graph/UnifiedGroupsUtility.cs
@@ -1166,8 +1166,9 @@ namespace OfficeDevPnP.Core.Framework.Graph
         /// </summary>
         /// <param name="groupId">The ID of the Office 365 Group</param>
         /// <param name="accessToken">The OAuth 2.0 Access Token to use for invoking the Microsoft Graph</param>
+        /// <param name="timeoutSeconds">Time to wait till Team is created. Default is 300 seconds (5 mins)</param>
         /// <returns></returns>
-        public static async Task CreateTeam(string groupId, string accessToken)
+        public static async Task CreateTeam(string groupId, string accessToken, int timeoutSeconds = 300)
         {
             if (string.IsNullOrEmpty(groupId))
             {
@@ -1197,17 +1198,17 @@ namespace OfficeDevPnP.Core.Framework.Graph
                 }
                 catch (Exception ex)
                 {
-                    // Don't wait more than 30 seconds
-                    if (iterations > 3)
+                    // Don't wait more than 300 seconds
+                    if (iterations * 30 >= timeoutSeconds)
                     {
                         wait = false;
                         throw;
                     }
                     else
                     {
-                        // In case of exception wait for 10 secs
+                        // In case of exception wait for 30 secs
                         Log.Error(Constants.LOGGING_SOURCE, CoreResources.GraphExtensions_ErrorOccured, ex.Message);
-                        System.Threading.Thread.Sleep(TimeSpan.FromSeconds(10));
+                        System.Threading.Thread.Sleep(TimeSpan.FromSeconds(30));
                     }
                 }
             }

--- a/Core/OfficeDevPnP.Core/Framework/Graph/UnifiedGroupsUtility.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Graph/UnifiedGroupsUtility.cs
@@ -1177,34 +1177,18 @@ namespace OfficeDevPnP.Core.Framework.Graph
             {
                 throw new ArgumentNullException(nameof(accessToken));
             }
-
-            bool wait = true;
-            int iterations = 0;
-            string createTeamEndPoint = GraphHttpClient.MicrosoftGraphV1BaseUri + $"groups/{groupId}/team";
-            while (wait)
+            var createTeamEndPoint = GraphHttpClient.MicrosoftGraphV1BaseUri + $"groups/{groupId}/team";
+            try
             {
-                iterations++;
-
-                try
+                await Task.Run(() =>
                 {
-                    await Task.Run(() =>
-                    {
-                        GraphHttpClient.MakePutRequest(createTeamEndPoint, new { }, "application/json", accessToken);
-                    });
-                }
-                catch (ServiceException ex)
-                {
-                    if (iterations > 3)
-                    {
-                        Log.Error(Constants.LOGGING_SOURCE, CoreResources.GraphExtensions_ErrorOccured, ex.Error.Message);
-                        wait = false;
-                        throw;
-                    }
-                    else
-                    {
-                        System.Threading.Thread.Sleep(TimeSpan.FromSeconds(10));
-                    }
-                }
+                    HttpHelper.MakePutRequestForString(createTeamEndPoint, new { }, "application/json", accessToken, retryCount: 3, delay:10000);
+                });
+            }
+            catch (ServiceException ex)
+            {
+                Log.Error(Constants.LOGGING_SOURCE, CoreResources.GraphExtensions_ErrorOccured, ex.Error.Message);
+                throw;
             }
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes https://github.com/SharePoint/PnP-PowerShell/issues/2397

#### What's in this Pull Request?

As mentioned in the issue as well as in the [docs](https://docs.microsoft.com/en-us/graph/api/team-put-teams?view=graph-rest-1.0&tabs=http) 

> If the group was created less than 15 minutes ago, it's possible for the Create team call to fail with a 404 error code due to replication delays. The recommended pattern is to retry the Create team call three times, with a 10 second delay between calls.

This PR adds a retry mechanism while creating a Team from Unified group.