### PR TITLE
Extend TokenParser with ParseStringSPGroupName to ensure valid SharePoint Group name

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -46,9 +46,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 if (web.EnsureProperty(w => w.HasUniqueRoleAssignments))
                 {
-                    string parsedAssociatedOwnerGroupName = parser.ParseString(template.Security.AssociatedOwnerGroup);
-                    string parsedAssociatedMemberGroupName = parser.ParseString(template.Security.AssociatedMemberGroup);
-                    string parsedAssociatedVisitorGroupName = parser.ParseString(template.Security.AssociatedVisitorGroup);
+                    string parsedAssociatedOwnerGroupName = parser.ParseStringSPGroupName(template.Security.AssociatedOwnerGroup);
+                    string parsedAssociatedMemberGroupName = parser.ParseStringSPGroupName(template.Security.AssociatedMemberGroup);
+                    string parsedAssociatedVisitorGroupName = parser.ParseStringSPGroupName(template.Security.AssociatedVisitorGroup);
 
                     bool setAssociatedOwnerGroup = parsedAssociatedOwnerGroupName != null;
                     bool setAssociatedMemberGroup = parsedAssociatedMemberGroupName != null;
@@ -278,7 +278,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     var allGroups = web.Context.LoadQuery(web.SiteGroups.Include(gr => gr.LoginName, gr => gr.Id));
                     web.Context.ExecuteQueryRetry();
 
-                    string parsedGroupTitle = parser.ParseString(siteGroup.Title);
+                    string parsedGroupTitle = parser.ParseStringSPGroupName(siteGroup.Title);
                     string parsedGroupOwner = parser.ParseString(siteGroup.Owner);
                     string parsedGroupDescription = parser.ParseString(siteGroup.Description);
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -1007,6 +1007,20 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return xmlDoc.OuterXml;
         }
 
+        private static readonly Regex ReInvalidSPGroupNameChars = new Regex(@"[""/\\\[\]:|<>+=;,?*'@]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        /// <summary>
+        /// Replaces invalid characters for SharePoint Group name.
+        /// Invalid characters are: " / \ [ ] : | &lt; &gt; + = ; , ? * ' @
+        /// </summary>
+        /// <param name="input">The group name value</param>
+        /// <returns>Returns a string where invalid characters are replaced with _</returns>
+        public string ParseStringSPGroupName(string input)
+        {
+            var parsedString = ParseString(input, null);
+            return ReInvalidSPGroupNameChars.Replace(parsedString, "_");
+        }
+
         internal void RemoveToken<T>(T oldToken) where T : TokenDefinition
         {
             for (int i = 0; i < _tokens.Count; i++)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

This PR ensures that the group name is always valid when provisioning a new SharePoint group.
It fixes issues where a token in Group Title prop could be parsed to a invalid character for a SharePoint Group title.

Example:

Site name: PnP/Sites/Core
Group title: "{sitename} Approvers"
parsedGroupTitle: "PnP/Sites/Core Approvers"

This will throw an error when the group is created.
