### PR TITLE
Make PnPHttpProvider respect SharePointPnPUserAgent setting

### DIFF
--- a/Core/OfficeDevPnP.Core/Utilities/PnPHttpProvider.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/PnPHttpProvider.cs
@@ -1,6 +1,7 @@
 ﻿using OfficeDevPnP.Core.Diagnostics;
 using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -76,6 +77,14 @@ namespace OfficeDevPnP.Core.Utilities
                 try
                 {
                     // Add the PnP User Agent string
+                    if(string.IsNullOrEmpty(userAgent))
+                    {
+                        userAgent = ConfigurationManager.AppSettings["SharePointPnPUserAgent"];
+                        if (string.IsNullOrWhiteSpace(userAgent))
+                        {
+                            userAgent = System.Environment.GetEnvironmentVariable("SharePointPnPUserAgent", EnvironmentVariableTarget.Process);
+                        }
+                    }
                     request.Headers.UserAgent.TryParseAdd(string.IsNullOrEmpty(userAgent) ? $"{PnPCoreUtilities.PnPCoreUserAgent}" : userAgent);
 
                     // Make the request


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Implement same logic then for ExecuteQueryRetry and make PnPHandler check for SharePointPnPUserAgent and set UserAgent string accordingly
