### PR TITLE
ExecuteQueryRetry include HttpStatusCode in Log.Warning

### DIFF
--- a/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
+++ b/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
@@ -19,7 +19,7 @@ namespace OfficeDevPnP.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CoreResources {
@@ -215,7 +215,7 @@ namespace OfficeDevPnP.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CSOM request frequency exceeded usage limits. Sleeping for {0} seconds before retrying..
+        ///   Looks up a localized string similar to CSOM request frequency exceeded usage limits (Status:{0}). Sleeping for {1} seconds before retrying..
         /// </summary>
         internal static string ClientContextExtensions_ExecuteQueryRetry {
             get {

--- a/Core/OfficeDevPnP.Core/CoreResources.resx
+++ b/Core/OfficeDevPnP.Core/CoreResources.resx
@@ -925,7 +925,7 @@
     <value>Could not find content type with id: {0}</value>
   </data>
   <data name="ClientContextExtensions_ExecuteQueryRetry" xml:space="preserve">
-    <value>CSOM request frequency exceeded usage limits. Sleeping for {0} seconds before retrying.</value>
+    <value>CSOM request frequency exceeded usage limits (Status:{0}). Sleeping for {1} seconds before retrying.</value>
   </data>
   <data name="Provisioning_Connectors_OpenXML_FileDeleted" xml:space="preserve">
     <value>File {0} deleted from folder {1}</value>

--- a/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
@@ -189,8 +189,8 @@ namespace Microsoft.SharePoint.Client
                         // || response.StatusCode == (HttpStatusCode)500
                         ))
                     {
-                        Log.Warning(Constants.LOGGING_SOURCE, CoreResources.ClientContextExtensions_ExecuteQueryRetry, backoffInterval);
-
+                        Log.Warning(Constants.LOGGING_SOURCE, CoreResources.ClientContextExtensions_ExecuteQueryRetry, (int)response.StatusCode, backoffInterval);
+                        
 #if !ONPREMISES
                         wrapper = (ClientRequestWrapper)wex.Data["ClientRequest"];
                         retry = true;
@@ -223,7 +223,7 @@ namespace Microsoft.SharePoint.Client
                     }
                     else
                     {
-                        Log.Error(Constants.LOGGING_SOURCE, CoreResources.ClientContextExtensions_ExecuteQueryRetryException, wex.ToString());
+                        Log.Error(Constants.LOGGING_SOURCE, CoreResources.ClientContextExtensions_ExecuteQueryRetryException, (response!=null?(int)response.StatusCode:0), wex.ToString());
                         throw;
                     }
                 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
It helps in Troubleshooting to know the HttpStatusCode trigger the Retry be included in the Logs.