### PR TITLE
Resolves issue where sharing settings defaults to disbled even when S…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Resolvers/V202002/SharingSettingsFromSchemaToModel.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Resolvers/V202002/SharingSettingsFromSchemaToModel.cs
@@ -38,7 +38,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.Resolvers.V2020
                 }
             }
 
-            return (result);
+            return (null);
         }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes

#### What's in this Pull Request?

As per item #2595 a simple change to `OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.Resolvers.V202002.SharingSettingsFromSchemaToModel` to return `null` when `SharingSettings` are not used in the template XML.
Currently it will return a default value which is `Disabled`
