### PR TITLE
Bugfix for authenticating with credentials containing special characters

### DIFF
--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -20,6 +20,7 @@ using OfficeDevPnP.Core.Utilities.Async;
 using System.Net.Http;
 using Newtonsoft.Json.Linq;
 using OfficeDevPnP.Core.Utilities.Context;
+using System.Web;
 
 namespace OfficeDevPnP.Core
 {
@@ -693,7 +694,7 @@ namespace OfficeDevPnP.Core
             HttpClient client = new HttpClient();
             string tokenEndpoint = $"{new AuthenticationManager().GetAzureADLoginEndPoint(environment)}/common/oauth2/token";
 
-            var body = $"resource={resourceUri}&client_id=9bc3ab49-b65d-410a-85ad-de819febfddc&grant_type=password&username={username}&password={password}";
+            var body = $"resource={resourceUri}&client_id=9bc3ab49-b65d-410a-85ad-de819febfddc&grant_type=password&username={HttpUtility.UrlEncode(username)}&password={HttpUtility.UrlEncode(password)}";
             var stringContent = new StringContent(body, System.Text.Encoding.UTF8, "application/x-www-form-urlencoded");
 
             var result = await client.PostAsync(tokenEndpoint, stringContent).ContinueWith<string>((response) =>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no 
| Related issues?  | N/A

#### What's in this Pull Request?

Using PnP PowerShell Connect-PnPOnline -Credentials (Get-Credential) with an username/password combination containing special characters would fail. URL Encoded these HTTP Form Post variables so they are correctly received by the Microsoft Online authentication endpoint.