### PR TITLE
Added functionality to allow PnP Templates to update docsets

### DIFF
--- a/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
+++ b/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
@@ -19,7 +19,7 @@ namespace OfficeDevPnP.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CoreResources {
@@ -1256,15 +1256,6 @@ namespace OfficeDevPnP.Core {
         internal static string Provisioning_ObjectHandlers_ContentTypes_Creating_new_Content_Type___0_____1_ {
             get {
                 return ResourceManager.GetString("Provisioning_ObjectHandlers_ContentTypes_Creating_new_Content_Type___0_____1_", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Content Type {0} with ID {1} cannot be updated because delta handling for DocumentSets is on hold..
-        /// </summary>
-        internal static string Provisioning_ObjectHandlers_ContentTypes_DocumentSet_DeltaHandling_OnHold {
-            get {
-                return ResourceManager.GetString("Provisioning_ObjectHandlers_ContentTypes_DocumentSet_DeltaHandling_OnHold", resourceCulture);
             }
         }
         

--- a/Core/OfficeDevPnP.Core/CoreResources.resx
+++ b/Core/OfficeDevPnP.Core/CoreResources.resx
@@ -873,9 +873,6 @@
   <data name="Provisioning_ObjectHandlers_ContentTypes_InvalidDocumentSet_Update_Request" xml:space="preserve">
     <value>Content Type {0} with ID {1} cannot be transformed into a DocumentSet</value>
   </data>
-  <data name="Provisioning_ObjectHandlers_ContentTypes_DocumentSet_DeltaHandling_OnHold" xml:space="preserve">
-    <value>Content Type {0} with ID {1} cannot be updated because delta handling for DocumentSets is on hold.</value>
-  </data>
   <data name="Provisioning_ObjectHandlers_SitePolicy_PolicyAdded" xml:space="preserve">
     <value>Site policy '{0}' applied to site</value>
   </data>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -99,7 +99,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 if ((!existingCT.Sealed || !ct.Sealed) && (!existingCT.ReadOnly || !ct.ReadOnly))
                                 {
                                     scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_ContentTypes_Updating_existing_Content_Type___0_____1_, ct.Id, ct.Name);
-                                    UpdateContentType(web, template, existingCT, ct, parser, scope);
+                                    UpdateContentType(web, template, existingCT, ct, parser, template.Connector, scope, existingCTs, existingFields, isNoScriptSite);
                                 }
                                 else
                                 {
@@ -130,12 +130,16 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             Microsoft.SharePoint.Client.ContentType existingContentType,
             ContentType templateContentType,
             TokenParser parser,
+            FileConnectorBase connector,
             PnPMonitoredScope scope,
+            List<Microsoft.SharePoint.Client.ContentType> existingCTs = null,
+            List<Microsoft.SharePoint.Client.Field> existingFields = null,
             bool isNoScriptSite = false
             )
         {
             var isDirty = false;
             var reOrderFields = false;
+            var name = parser.ParseString(templateContentType.Name);
 
             if (existingContentType.Hidden != templateContentType.Hidden)
             {
@@ -334,11 +338,101 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 else
                 {
-                    Microsoft.SharePoint.Client.DocumentSet.DocumentSetTemplate templateToUpdate =
+                    // Retrieve a reference to the DocumentSet Content Type
+                    Microsoft.SharePoint.Client.DocumentSet.DocumentSetTemplate documentSetTemplate =
                         Microsoft.SharePoint.Client.DocumentSet.DocumentSetTemplate.GetDocumentSetTemplate(web.Context, existingContentType);
 
-                    // TODO: Implement Delta Handling
-                    scope.LogWarning(CoreResources.Provisioning_ObjectHandlers_ContentTypes_DocumentSet_DeltaHandling_OnHold, existingContentType.Id, existingContentType.Name);
+                    // Keep a flag if changes have been made to the document set of the content type
+                    var documentSetIsDirty = false;
+
+                    // Load the collections to allow for deletion scenarions
+                    web.Context.Load(documentSetTemplate, d => d.AllowedContentTypes, d => d.DefaultDocuments, d => d.SharedFields, d => d.WelcomePageFields);
+                    web.Context.ExecuteQueryRetry();
+
+                    if (!String.IsNullOrEmpty(templateContentType.DocumentSetTemplate.WelcomePage))
+                    {
+                        // TODO: Customize the WelcomePage of the DocumentSet
+                    }
+
+                    // AllowedContentTypes
+                    // Add additional content types to the set of allowed content types
+                    foreach (string ctId in templateContentType.DocumentSetTemplate.AllowedContentTypes)
+                    {
+                        Microsoft.SharePoint.Client.ContentType ct = existingCTs.FirstOrDefault(c => c.StringId == ctId);
+                        if (ct != null)
+                        {
+                            // Validate if the content type is not part of the document set content types yet
+                            if (documentSetTemplate.AllowedContentTypes.All(d => d.StringValue != ctId))
+                            {
+                                documentSetTemplate.AllowedContentTypes.Add(ct.Id);
+                                documentSetIsDirty = true;
+                            }
+                        }
+                    }
+
+                    // DefaultDocuments
+                    if (!isNoScriptSite)
+                    {
+                        foreach (var doc in templateContentType.DocumentSetTemplate.DefaultDocuments)
+                        {
+                            Microsoft.SharePoint.Client.ContentType ct = existingCTs.FirstOrDefault(c => c.StringId == doc.ContentTypeId);
+                            if (ct != null)
+                            {
+                                // Ensure the default document is not part of the document set yet
+                                if (documentSetTemplate.DefaultDocuments.All(d => d.Name != doc.Name))
+                                {
+                                    using (Stream fileStream = connector.GetFileStream(doc.FileSourcePath))
+                                    {
+                                        documentSetTemplate.DefaultDocuments.Add(doc.Name, ct.Id, ReadFullStream(fileStream));
+                                        documentSetIsDirty = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (templateContentType.DocumentSetTemplate.DefaultDocuments.Any())
+                        {
+                            scope.LogWarning(CoreResources.Provisioning_ObjectHandlers_ContentTypes_SkipDocumentSetDefaultDocuments, name);
+                        }
+                    }
+
+                    // SharedFields
+                    foreach (var sharedField in templateContentType.DocumentSetTemplate.SharedFields)
+                    {
+                        Microsoft.SharePoint.Client.Field field = existingFields.FirstOrDefault(f => f.Id == sharedField);
+                        if (field != null)
+                        {
+                            // Ensure the shared field is not part of the document set yet
+                            if (documentSetTemplate.SharedFields.All(f => f.Id != field.Id))
+                            {
+                                documentSetTemplate.SharedFields.Add(field);
+                                documentSetIsDirty = true;
+                            }
+                        }
+                    }
+
+                    // WelcomePageFields
+                    foreach (var welcomePageField in templateContentType.DocumentSetTemplate.WelcomePageFields)
+                    {
+                        Microsoft.SharePoint.Client.Field field = existingFields.FirstOrDefault(f => f.Id == welcomePageField);
+                        if (field != null)
+                        {
+                            // Ensure the welcomepage field is not part of the document set yet
+                            if (documentSetTemplate.WelcomePageFields.All(w => w.Id != field.Id))
+                            {
+                                documentSetTemplate.WelcomePageFields.Add(field);
+                                documentSetIsDirty = true;
+                            }
+                        }
+                    }
+
+                    if (documentSetIsDirty)
+                    {
+                        documentSetTemplate.Update(true);
+                        isDirty = true;
+                    }
                 }
             }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -358,11 +358,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     // Add additional content types to the set of allowed content types
                     foreach (string ctId in templateContentType.DocumentSetTemplate.AllowedContentTypes)
                     {
-                        Microsoft.SharePoint.Client.ContentType ct = existingCTs.FirstOrDefault(c => c.StringId == ctId);
-                        if (ct != null)
+                        // Validate if the content type is not part of the document set content types yet
+                        if (documentSetTemplate.AllowedContentTypes.All(d => d.StringValue != ctId))
                         {
-                            // Validate if the content type is not part of the document set content types yet
-                            if (documentSetTemplate.AllowedContentTypes.All(d => d.StringValue != ctId))
+                            Microsoft.SharePoint.Client.ContentType ct = existingCTs.FirstOrDefault(c => c.StringId == ctId);
+                            if (ct != null)
                             {
                                 documentSetTemplate.AllowedContentTypes.Add(ct.Id);
                                 documentSetIsDirty = true;
@@ -374,12 +374,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     if (!isNoScriptSite)
                     {
                         foreach (var doc in templateContentType.DocumentSetTemplate.DefaultDocuments)
-                        {
-                            Microsoft.SharePoint.Client.ContentType ct = existingCTs.FirstOrDefault(c => c.StringId == doc.ContentTypeId);
-                            if (ct != null)
+                        {                                
+                            // Ensure the default document is not part of the document set yet
+                            if (documentSetTemplate.DefaultDocuments.All(d => d.Name != doc.Name))
                             {
-                                // Ensure the default document is not part of the document set yet
-                                if (documentSetTemplate.DefaultDocuments.All(d => d.Name != doc.Name))
+                                Microsoft.SharePoint.Client.ContentType ct = existingCTs.FirstOrDefault(c => c.StringId == doc.ContentTypeId);
+                                if (ct != null)
                                 {
                                     using (Stream fileStream = connector.GetFileStream(doc.FileSourcePath))
                                     {
@@ -400,12 +400,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                     // SharedFields
                     foreach (var sharedField in templateContentType.DocumentSetTemplate.SharedFields)
-                    {
-                        Microsoft.SharePoint.Client.Field field = existingFields.FirstOrDefault(f => f.Id == sharedField);
-                        if (field != null)
+                    {                            
+                        // Ensure the shared field is not part of the document set yet
+                        if (documentSetTemplate.SharedFields.All(f => f.Id != sharedField))
                         {
-                            // Ensure the shared field is not part of the document set yet
-                            if (documentSetTemplate.SharedFields.All(f => f.Id != field.Id))
+                            Microsoft.SharePoint.Client.Field field = existingFields.FirstOrDefault(f => f.Id == sharedField);
+                            if (field != null)
                             {
                                 documentSetTemplate.SharedFields.Add(field);
                                 documentSetIsDirty = true;
@@ -416,11 +416,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     // WelcomePageFields
                     foreach (var welcomePageField in templateContentType.DocumentSetTemplate.WelcomePageFields)
                     {
-                        Microsoft.SharePoint.Client.Field field = existingFields.FirstOrDefault(f => f.Id == welcomePageField);
-                        if (field != null)
+                        // Ensure the welcomepage field is not part of the document set yet
+                        if (documentSetTemplate.WelcomePageFields.All(w => w.Id != welcomePageField))
                         {
-                            // Ensure the welcomepage field is not part of the document set yet
-                            if (documentSetTemplate.WelcomePageFields.All(w => w.Id != field.Id))
+                            Microsoft.SharePoint.Client.Field field = existingFields.FirstOrDefault(f => f.Id == welcomePageField);
+                            if (field != null)
                             {
                                 documentSetTemplate.WelcomePageFields.Add(field);
                                 documentSetIsDirty = true;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no 
| Related issues?  | N/A

#### What's in this Pull Request?

Added functionality to allow a PnP Template to update the following features on a document set:

- WelcomePageFields
- SharedFields
- AllowedContentTypes
- DefaultDocuments

Before this change, they would only be applied on initial run when the document sets would be created by the PnP Provisioning engine.