### PR TITLE
Fix: additional check to determine whether theme exists in the tenant

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHierarchySequenceSites.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHierarchySequenceSites.cs
@@ -222,6 +222,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                     TokenParser siteTokenParser = null;
 
+                    var tenantThemes = tenant.GetAllTenantThemes();
+                    tenant.Context.Load(tenantThemes);
+                    tenant.Context.ExecuteQueryRetry();
 
                     foreach (var sitecollection in sequence.SiteCollections)
                     {
@@ -264,8 +267,15 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     if (!string.IsNullOrEmpty(t.Theme))
                                     {
                                         var parsedTheme = tokenParser.ParseString(t.Theme);
-                                        tenant.SetWebTheme(parsedTheme, siteContext.Url);
-                                        tenant.Context.ExecuteQueryRetry();
+                                        if (tenantThemes.FirstOrDefault(th => th.Name == parsedTheme) != null)
+                                        {
+                                            tenant.SetWebTheme(parsedTheme, siteContext.Url);
+                                            tenant.Context.ExecuteQueryRetry();
+                                        }
+                                        else
+                                        {
+                                            WriteMessage($"Theme {parsedTheme} doesn't exist in the tenant, will not be applied", ProvisioningMessageType.Warning);
+                                        }
                                     }
                                     if (t.Teamify)
                                     {
@@ -363,8 +373,15 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     if (!string.IsNullOrEmpty(c.Theme))
                                     {
                                         var parsedTheme = tokenParser.ParseString(c.Theme);
-                                        tenant.SetWebTheme(parsedTheme, siteInfo.Url);
-                                        tenant.Context.ExecuteQueryRetry();
+                                        if (tenantThemes.FirstOrDefault(th => th.Name == parsedTheme) != null)
+                                        {
+                                            tenant.SetWebTheme(parsedTheme, siteInfo.Url);
+                                            tenant.Context.ExecuteQueryRetry();
+                                        }
+                                        else
+                                        {
+                                            WriteMessage($"Theme {parsedTheme} doesn't exist in the tenant, will not be applied", ProvisioningMessageType.Warning);
+                                        }
                                     }
                                     siteUrls.Add(c.Id, siteInfo.Url);
                                     if (!string.IsNullOrEmpty(c.ProvisioningId))
@@ -414,8 +431,15 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     if (!string.IsNullOrEmpty(t.Theme))
                                     {
                                         var parsedTheme = tokenParser.ParseString(t.Theme);
-                                        tenant.SetWebTheme(parsedTheme, siteContext.Url);
-                                        tenant.Context.ExecuteQueryRetry();
+                                        if (tenantThemes.FirstOrDefault(th => th.Name == parsedTheme) != null)
+                                        {
+                                            tenant.SetWebTheme(parsedTheme, siteContext.Url);
+                                            tenant.Context.ExecuteQueryRetry();
+                                        }
+                                        else
+                                        {
+                                            WriteMessage($"Theme {parsedTheme} doesn't exist in the tenant, will not be applied", ProvisioningMessageType.Warning);
+                                        }                                        
                                     }
                                     siteUrls.Add(t.Id, siteContext.Url);
                                     if (!string.IsNullOrEmpty(t.ProvisioningId))


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

This PR adds an additional check to determine whether a particular custom theme exists in the tenant. If it exists, we will apply that theme, otherwise will show a warning and skip it. Currently, if the theme doesn't exist, the provisioning stops at this stage only