### PR TITLE
Fix client side web part parser description was mapped to title

### DIFF
--- a/Core/OfficeDevPnP.Core/Pages/ClientSideWebPart.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSideWebPart.cs
@@ -659,7 +659,7 @@ namespace OfficeDevPnP.Core.Pages
                 }
                 if (wpJObject["webPartData"] != null && wpJObject["webPartData"]["description"] != null)
                 {
-                    this.title = wpJObject["webPartData"]["description"].Value<string>();
+                    this.description = wpJObject["webPartData"]["description"].Value<string>();
                 }
                 if (wpJObject["webPartData"] != null && wpJObject["webPartData"]["properties"] != null)
                 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | f

#### What's in this Pull Request?
The Parser in the ClientSideWebPart had the extracted Description-Field mapped to the Title-Field - corrected that.