### PR TITLE
Fix when sitelogo file contains spaces which will be encoded as %20. …

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
@@ -134,7 +134,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                         if (PersistFile(web, creationInfo, scope, siteLogoServerRelativeUrl))
                         {
-                            template.Files.Add(GetTemplateFile(web, siteLogoServerRelativeUrl));
+                            template.Files.Add(GetTemplateFile(web, HttpUtility.UrlDecode(siteLogoServerRelativeUrl)));
                         }
                     }
                     if (!string.IsNullOrEmpty(web.AlternateCssUrl))


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
The site-logo-file will not be found during provisioning since the file itself has the decoded name but the siteLogoServerRelativeUrl contains the encoded filename.