### PR TITLE
Handle special char in SiteTile beeing replaced by _ for SP-Groupnames

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
@@ -31,7 +31,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
             {
                 if (!roleAssignment.Remove)
                 {
-                    var roleAssignmentPrincipal = parser.ParseString(roleAssignment.Principal);
+                    var roleAssignmentPrincipal = parser.ParseGroupTitleString(roleAssignment.Principal, context.Web);
 
                     Principal principal = groups.FirstOrDefault(g => g.LoginName.Equals(roleAssignmentPrincipal, StringComparison.OrdinalIgnoreCase));
 
@@ -64,7 +64,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
                     }
                 } else
                 {
-                    var roleAssignmentPrincipal = parser.ParseString(roleAssignment.Principal);
+                    var roleAssignmentPrincipal = parser.ParseGroupTitleString(roleAssignment.Principal, context.Web);
 
                     Principal principal = groups.FirstOrDefault(g => g.LoginName.Equals(roleAssignmentPrincipal, StringComparison.OrdinalIgnoreCase));
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -46,9 +46,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 if (web.EnsureProperty(w => w.HasUniqueRoleAssignments))
                 {
-                    string parsedAssociatedOwnerGroupName = parser.ParseString(template.Security.AssociatedOwnerGroup);
-                    string parsedAssociatedMemberGroupName = parser.ParseString(template.Security.AssociatedMemberGroup);
-                    string parsedAssociatedVisitorGroupName = parser.ParseString(template.Security.AssociatedVisitorGroup);
+                    string parsedAssociatedOwnerGroupName = parser.ParseGroupTitleString(template.Security.AssociatedOwnerGroup,web);
+                    string parsedAssociatedMemberGroupName = parser.ParseGroupTitleString(template.Security.AssociatedMemberGroup, web);
+                    string parsedAssociatedVisitorGroupName = parser.ParseGroupTitleString(template.Security.AssociatedVisitorGroup, web);
 
                     bool setAssociatedOwnerGroup = parsedAssociatedOwnerGroupName != null;
                     bool setAssociatedMemberGroup = parsedAssociatedMemberGroupName != null;
@@ -278,8 +278,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     var allGroups = web.Context.LoadQuery(web.SiteGroups.Include(gr => gr.LoginName, gr => gr.Id));
                     web.Context.ExecuteQueryRetry();
 
-                    string parsedGroupTitle = parser.ParseString(siteGroup.Title);
-                    string parsedGroupOwner = parser.ParseString(siteGroup.Owner);
+                    string parsedGroupTitle = parser.ParseGroupTitleString(siteGroup.Title,web);
+                    string parsedGroupOwner = parser.ParseGroupTitleString(siteGroup.Owner,web);
                     string parsedGroupDescription = parser.ParseString(siteGroup.Description);
 
                     if (!web.GroupExists(parsedGroupTitle))
@@ -630,7 +630,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         private static Principal GetPrincipal(Web web, TokenParser parser, PnPMonitoredScope scope, IEnumerable<Group> groups, Model.RoleAssignment roleAssignment)
         {
-            var parsedRoleDefinition = parser.ParseString(roleAssignment.Principal);
+            var parsedRoleDefinition = parser.ParseGroupTitleString(roleAssignment.Principal,web);
             Principal principal = groups.FirstOrDefault(g => g.LoginName.Equals(parsedRoleDefinition, StringComparison.OrdinalIgnoreCase));
 
             if (principal == null)

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -738,6 +738,18 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return ParseString(input, null);
         }
 
+        public string ParseGroupTitleString(string input, Web web)
+        {
+            web.EnsureProperty(w => w.Title);
+            string siteTitle = web.Title;
+            //If User creates site from ms ui using special char in title they will be replaced by _
+            //The group name is empty, or you are using one or more of the following invalid characters: " / \ [ ] : | < > + = ; , ? * ' @
+            siteTitle = Regex.Replace(siteTitle, "[\"/\\[\\]\\\\:|<>+=;,?*\'@]", "_");
+            input=Regex.Replace(input, "{sitetitle}", siteTitle);
+            input = Regex.Replace(input, "{sitename}", siteTitle);
+            return ParseString(input, null);
+        }
+
         static readonly Regex ReGuid = new Regex("(?<guid>\\{\\S{8}-\\S{4}-\\S{4}-\\S{4}-\\S{12}?\\})", RegexOptions.Compiled);
         /// <summary>
         /// Gets left over tokens


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
If site with title using special chars are created - you will get the Error: 
The group name is empty, or you are using one or more of the following invalid characters: " / \ [ ] : | < > + = ; , ? * ' @

Explanation: If the user creates a site with Title "there's my site" then microsoft names the SP Groups "there_s my site Owner". This leads to the issue that tokenized groups like "{sitename} Owner" will not be resolved correctly. This fix implements the same replacement logic as ms using in UI in the new ParseGroupTitleString in order to fix this issue.
