### PR TITLE
Fix preserve SPGroup Config also for Associated Groups

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -802,7 +802,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     {
                         WriteMessage("You are requesting to export sitegroups from a subweb. Notice that ALL sitegroups from the site collection are included in the result.", ProvisioningMessageType.Warning);
                     }
-                    foreach (var group in web.SiteGroups.AsEnumerable().Where(o => !associatedGroupIds.Contains(o.Id)))
+                    //preserve all Group Settings - also for Associated Groups since otherwise those Group Configs are lost
+                    foreach (var group in web.SiteGroups.AsEnumerable()) //.Where(o => !associatedGroupIds.Contains(o.Id)))
                     {
                         try
                         {
@@ -832,10 +833,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 }
                             }
 
-                            foreach (var member in group.Users)
+                            //make sure we not include Members twice as they are alreday in AdditionalOwner/Member/Visitor
+                            if (!associatedGroupIds.Contains(group.Id))
                             {
-                                scope.LogDebug("Processing member {0} of group {0}", member.LoginName, group.Title);
-                                siteGroup.Members.Add(new User() { Name = member.LoginName });
+                                foreach (var member in group.Users)
+                                {
+                                    scope.LogDebug("Processing member {0} of group {0}", member.LoginName, group.Title);
+                                    siteGroup.Members.Add(new User() { Name = member.LoginName });
+                                }
                             }
                             siteSecurity.SiteGroups.Add(siteGroup);
                         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Error: Settings on Associated Groups are not stored in Pnp-XML as on the Associated Groups are no properties to store the values.  

Fix: Export Associated Groups as SiteGroups without member - since members are already in Associated Group. The fix is important as "Change how members can share" is changing the setting on Associated Group on who can read members. 
