### PR TITLE
Revert "Fix: ensuring correct usage of EnsureProperties method"

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Extensions/ClientObjectExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Extensions/ClientObjectExtensionsTests.cs
@@ -278,7 +278,7 @@ namespace OfficeDevPnP.Core.Tests.AppModelExtensions
                 //at this stage clientContext.Web.IsObjectPropertyInstantiated("Fields") will be true
                 //but actually Fields are not loaded, CollectionNotInitializedException will be thrown when trying to access the collection
 
-                clientContext.Web.EnsureProperty(w => w.Fields);
+                clientContext.Web.EnsureProperties(w => w.Fields);
 
                 //Act
                 var fieldTitle2 = clientContext.Web.Fields.FirstOrDefault(f => f.Title.Equals("Title"));

--- a/Core/OfficeDevPnP.Core.Tests/Extensions/SecurityExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Extensions/SecurityExtensionsTests.cs
@@ -201,7 +201,7 @@ namespace Microsoft.SharePoint.Client.Tests
 				//Arrange
 				var subSite = CreateTestTeamSubSite(clientContext.Web);
 
-                subSite.EnsureProperty(s => s.HasUniqueRoleAssignments);
+                subSite.EnsureProperties(s => s.HasUniqueRoleAssignments);
 				
 				if (!subSite.HasUniqueRoleAssignments)
 				{
@@ -232,7 +232,7 @@ namespace Microsoft.SharePoint.Client.Tests
 				//Arrange
 				var list = clientContext.Web.CreateList(ListTemplateType.GenericList, GetRandomString(), false);
 
-                list.EnsureProperty(l => l.HasUniqueRoleAssignments);
+                list.EnsureProperties(l => l.HasUniqueRoleAssignments);
                 
 				if (!list.HasUniqueRoleAssignments)
 				{
@@ -268,7 +268,7 @@ namespace Microsoft.SharePoint.Client.Tests
 				clientContext.Load(item);
 				clientContext.ExecuteQueryRetry();
 
-                item.EnsureProperty(i => i.HasUniqueRoleAssignments);
+                item.EnsureProperties(i => i.HasUniqueRoleAssignments);
 				
 				if (!item.HasUniqueRoleAssignments)
 				{
@@ -300,7 +300,7 @@ namespace Microsoft.SharePoint.Client.Tests
 				var subSite = CreateTestTeamSubSite(clientContext.Web);
 
 
-                subSite.EnsureProperty(s => s.HasUniqueRoleAssignments);
+                subSite.EnsureProperties(s => s.HasUniqueRoleAssignments);
 				
 				if (!subSite.HasUniqueRoleAssignments)
 				{

--- a/Core/OfficeDevPnP.Core.Tests/Framework/Functional/Implementation/LocalizationImplementation.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/Functional/Implementation/LocalizationImplementation.cs
@@ -150,7 +150,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Functional.Implementation
         private void DeletePages(ClientContext cc)
         {
             Web web = cc.Web;
-            web.EnsureProperty(w => w.ServerRelativeUrl);
+            web.EnsureProperties(w => w.ServerRelativeUrl);
             string serverRelatedUrl = web.ServerRelativeUrl;
 
             try

--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectFilesTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectFilesTests.cs
@@ -66,7 +66,7 @@ alert(""Hello!"");
         {
             using (var ctx = TestCommon.CreateClientContext())
             {
-                ctx.Web.EnsureProperty(w => w.ServerRelativeUrl);
+                ctx.Web.EnsureProperties(w => w.ServerRelativeUrl);
 
                 var file = ctx.Web.GetFileByServerRelativeUrl(UrlUtility.Combine(ctx.Web.ServerRelativeUrl, "test/" + fileName));
                 ctx.Load(file, f => f.Exists);
@@ -102,7 +102,7 @@ alert(""Hello!"");
                 new ObjectFiles().ProvisionObjects(ctx.Web, template, parser, new ProvisioningTemplateApplyingInformation());
 
 
-                ctx.Web.EnsureProperty(w => w.ServerRelativeUrl);
+                ctx.Web.EnsureProperties(w => w.ServerRelativeUrl);
                 var serverRelativeUrl = UrlUtility.Combine(ctx.Web.ServerRelativeUrl, UrlUtility.Combine(folder, fileName));
                 var file = ctx.Web.GetFileByServerRelativeUrl(serverRelativeUrl);
                 
@@ -158,7 +158,7 @@ alert(""Hello!"");
                 var parser = new TokenParser(ctx.Web, template);
                 new ObjectFiles().ProvisionObjects(ctx.Web, template, parser, new ProvisioningTemplateApplyingInformation());
 
-                ctx.Web.EnsureProperty(w => w.ServerRelativeUrl);
+                ctx.Web.EnsureProperties(w => w.ServerRelativeUrl);
 
                 var file = ctx.Web.GetFileByServerRelativeUrl(
                     UrlUtility.Combine(ctx.Web.ServerRelativeUrl,
@@ -218,7 +218,7 @@ alert(""Hello!"");
                 new ObjectFiles().ProvisionObjects(ctx.Web, template, parser, new ProvisioningTemplateApplyingInformation());
 
 
-                ctx.Web.EnsureProperty(w => w.ServerRelativeUrl);
+                ctx.Web.EnsureProperties(w => w.ServerRelativeUrl);
 
                 var file = ctx.Web.GetFileByServerRelativeUrl(
                     UrlUtility.Combine(ctx.Web.ServerRelativeUrl,

--- a/Core/OfficeDevPnP.Core.Tests/Utilities/WebParts/XsltWebPartPostProcessorTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Utilities/WebParts/XsltWebPartPostProcessorTests.cs
@@ -66,14 +66,14 @@ namespace OfficeDevPnP.Core.Tests.Utilities.WebParts
             using (var ctx = TestCommon.CreateClientContext())
             {
                 var docsList = ctx.Web.GetListByUrl(TestListUrl);
-                docsList.EnsureProperty(d => d.Id);
+                docsList.EnsureProperties(d => d.Id);
                 var newView = docsList.Views.Add(new ViewCreationInformation
                 {
                     Title = ViewName
                 });
                 newView.ListViewXml = ViewXml;
                 newView.Update();
-                newView.EnsureProperty(v => v.Id);
+                newView.EnsureProperties(v => v.Id);
                 ctx.ExecuteQueryRetry();
                 _viewId = newView.Id;
                 _docsListId = docsList.Id;
@@ -113,7 +113,7 @@ namespace OfficeDevPnP.Core.Tests.Utilities.WebParts
         {
             using (var ctx = TestCommon.CreateClientContext())
             {
-                ctx.Web.EnsureProperty(w => w.ServerRelativeUrl);
+                ctx.Web.EnsureProperties(w => w.ServerRelativeUrl);
 
                 if (ctx.Web.RootFolder.FolderExists(folder))
                 {
@@ -419,7 +419,7 @@ namespace OfficeDevPnP.Core.Tests.Utilities.WebParts
                     childWeb = CreateTestTeamSubSite(ctx.Web);
                     childWeb.EnsureProperty(w => w.Id);
                     var docsList = childWeb.GetListByUrl(TestListUrl);
-                    docsList.EnsureProperty(l => l.Id);
+                    docsList.EnsureProperties(l => l.Id);
                     var wpXml =
                     $@"<webParts>
                         <webPart xmlns=""http://schemas.microsoft.com/WebPart/v3"">
@@ -484,7 +484,7 @@ namespace OfficeDevPnP.Core.Tests.Utilities.WebParts
 
         private void AssertViewIsValid(View view)
         {
-            view.EnsureProperty(v => v.ViewFields);
+            view.EnsureProperties(v => v.ViewFields);
 
             Assert.AreEqual(view.JSLink, "my_link.js");
             Assert.AreEqual(view.Aggregations, @"<FieldRef Name=""DocIcon"" Type=""COUNT"" />");
@@ -499,7 +499,7 @@ namespace OfficeDevPnP.Core.Tests.Utilities.WebParts
 
         private File GetFile(ClientContext ctx)
         {
-            ctx.Web.EnsureProperty(w => w.ServerRelativeUrl);
+            ctx.Web.EnsureProperties(w => w.ServerRelativeUrl);
 
             var serverRelativeUrl = UrlUtility.Combine(ctx.Web.ServerRelativeUrl, $"{folder}/{testPage}");
             var webPartPage = ctx.Web.GetFileByServerRelativeUrl(serverRelativeUrl);

--- a/Core/OfficeDevPnP.Core/Extensions/BrandingExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/BrandingExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.SharePoint.Client
             var backgroundUrl = default(string);
             var masterUrl = default(string);
 
-            web.EnsureProperty(w => w.ServerRelativeUrl);
+            web.EnsureProperties(w => w.ServerRelativeUrl);
 
             if (!string.IsNullOrEmpty(paletteFileName))
             {
@@ -105,7 +105,7 @@ namespace Microsoft.SharePoint.Client
         /// <param name="replaceContent">Replace composed look if it already exists (default true)</param>
         public static void CreateComposedLookByUrl(this Web web, string lookName, string paletteServerRelativeUrl, string fontServerRelativeUrl, string backgroundServerRelativeUrl, string masterServerRelativeUrl, int displayOrder = 1, bool replaceContent = true)
         {
-            web.EnsureProperty(w => w.ServerRelativeUrl);
+            web.EnsureProperties(w => w.ServerRelativeUrl);
 
             var composedLooksList = web.GetCatalog((int)ListTemplateType.DesignCatalog);
 
@@ -721,7 +721,7 @@ namespace Microsoft.SharePoint.Client
 
         private static string GetLocalizedCurrentValue(this Web web)
         {
-            web.EnsureProperty(w => w.Language);
+            web.EnsureProperties(w => w.Language);
             ClientResult<string> currentTranslated = Utilities.Utility.GetLocalizedString(web.Context, "$Resources:Current", "core", (int)web.Language);
             web.Context.ExecuteQueryRetry();
             return currentTranslated.Value;
@@ -1354,7 +1354,7 @@ namespace Microsoft.SharePoint.Client
             if (string.IsNullOrEmpty(url))
                 throw new ArgumentNullException(nameof(url));
 
-            web.EnsureProperty(w => w.ServerRelativeUrl);
+            web.EnsureProperties(w => w.ServerRelativeUrl);
 
             string newUrl = url.Substring(web.ServerRelativeUrl.Length);
             if (newUrl.Length > 0 && newUrl[0] == '/')

--- a/Core/OfficeDevPnP.Core/Extensions/FeatureExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FeatureExtensions.cs
@@ -243,7 +243,7 @@ namespace Microsoft.SharePoint.Client
             }
 
             var iprFeature = features.GetById(featureID);
-            iprFeature.EnsureProperty(f => f.DefinitionId);
+            iprFeature.EnsureProperties(f => f.DefinitionId);
 
             if (iprFeature != null && iprFeature.IsPropertyAvailable("DefinitionId") && !iprFeature.ServerObjectIsNull.Value && iprFeature.DefinitionId.Equals(featureID))
             {

--- a/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
@@ -1807,7 +1807,7 @@ namespace Microsoft.SharePoint.Client
                 throw new ArgumentNullException(nameof(contentTypeId));
             }
             var ctx = contentTypes.Context;
-            contentTypes.EnsureProperty(c => c.Include(ct => ct.Id));
+            contentTypes.EnsureProperties(c => c.Include(ct => ct.Id));
 
             var res = contentTypes.Where(c => c.Id.StringValue.StartsWith(contentTypeId, StringComparison.InvariantCultureIgnoreCase)).OrderBy(c => c.Id.StringValue.Length).FirstOrDefault();
             if (res != null)

--- a/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
@@ -403,7 +403,7 @@ namespace Microsoft.SharePoint.Client
         private static async Task<Folder> ConvertFolderToDocumentSetImplementation(this List list, Folder folder)
         {
 #endif
-            list.EnsureProperty(l => l.ContentTypes.Include(c => c.StringId));
+            list.EnsureProperties(l => l.ContentTypes.Include(c => c.StringId));
             folder.Context.Load(folder.ListItemAllFields, l => l["ContentTypeId"]);
             folder.Context.ExecuteQueryRetry();
             var listItem = folder.ListItemAllFields;
@@ -731,8 +731,8 @@ namespace Microsoft.SharePoint.Client
 #if ONPREMISES
         public static Folder EnsureFolderImplementation(this Web web, Folder parentFolder, string folderPath, params Expression<Func<Folder, object>>[] expressions)
         {
-            web.EnsureProperty(w => w.ServerRelativeUrl);
-            parentFolder.EnsureProperty(f => f.ServerRelativeUrl);
+            web.EnsureProperties(w => w.ServerRelativeUrl);
+            parentFolder.EnsureProperties(f => f.ServerRelativeUrl);
 #else
         public static async Task<Folder> EnsureFolderImplementation(this Web web, Folder parentFolder, string folderPath, params Expression<Func<Folder, object>>[] expressions)
         {
@@ -1956,7 +1956,7 @@ namespace Microsoft.SharePoint.Client
 
             try
             {
-                folder.EnsureProperty(f => f.ServerRelativeUrl);
+                folder.EnsureProperties(f => f.ServerRelativeUrl);
 
                 var fileServerRelativeUrl = UrlUtility.Combine(folder.ServerRelativeUrl, fileName);
                 var context = folder.Context as ClientContext;

--- a/Core/OfficeDevPnP.Core/Extensions/ListExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ListExtensions.cs
@@ -2210,7 +2210,7 @@ namespace Microsoft.SharePoint.Client
         /// <param name="list">List to process</param>
         public static void ReIndexList(this List list)
         {
-            list.EnsureProperty(l => l.NoCrawl);
+            list.EnsureProperties(l => l.NoCrawl);
             if (list.NoCrawl)
             {
                 Log.Warning(Constants.LOGGING_SOURCE, CoreResources.ListExtensions_SkipNoCrawlLists);

--- a/Core/OfficeDevPnP.Core/Extensions/PageExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/PageExtensions.cs
@@ -1133,10 +1133,10 @@ namespace Microsoft.SharePoint.Client
                 using (var context = currentContext.Clone(fileWeb.Url))
                 {
 #if !SP2013
-                    webPartPage.EnsureProperty(f => f.UniqueId);
+                    webPartPage.EnsureProperties(f => f.UniqueId);
                     var file = context.Web.GetFileById(webPartPage.UniqueId);
 #else
-                    webPartPage.EnsureProperty(f => f.ServerRelativeUrl);
+                    webPartPage.EnsureProperties(f => f.ServerRelativeUrl);
                     var file = context.Web.GetFileByServerRelativeUrl(webPartPage.ServerRelativeUrl);
 #endif
                     webPartPostProcessor.Process(wpdNew, file);

--- a/Core/OfficeDevPnP.Core/Extensions/TaxonomyExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/TaxonomyExtensions.cs
@@ -2101,7 +2101,7 @@ namespace Microsoft.SharePoint.Client
             if (termSet == default(TermSet))
                 throw new ArgumentException("Bound TaxonomyItem must be either a TermSet or a Term");
 
-            termSet.EnsureProperty(ts => ts.TermStore);
+            termSet.EnsureProperties(ts => ts.TermStore);
 
             // set the SSP ID and Term Set ID on the taxonomy field
             var taxField = clientContext.CastTo<TaxonomyField>(field);

--- a/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
@@ -114,7 +114,7 @@ namespace Microsoft.SharePoint.Client
             }
 
             var deleted = false;
-            parentWeb.EnsureProperty(w => w.ServerRelativeUrl);
+            parentWeb.EnsureProperties(w => w.ServerRelativeUrl);
 
             var serverRelativeUrl = UrlUtility.Combine(parentWeb.ServerRelativeUrl, leafUrl);
             var webs = parentWeb.Webs;
@@ -215,7 +215,7 @@ namespace Microsoft.SharePoint.Client
                 throw new ArgumentException("The argument must be a single web URL and cannot contain path characters.", nameof(leafUrl));
             }
 
-            parentWeb.EnsureProperty(w => w.ServerRelativeUrl);
+            parentWeb.EnsureProperties(w => w.ServerRelativeUrl);
 
             var serverRelativeUrl = UrlUtility.Combine(parentWeb.ServerRelativeUrl, leafUrl);
             var webs = parentWeb.Webs;
@@ -343,7 +343,7 @@ namespace Microsoft.SharePoint.Client
         public static bool IsNoScriptSite(this Web web)
         {
 #if !SP2013 && !SP2016
-            web.EnsureProperty(w => w.EffectiveBasePermissions);
+            web.EnsureProperties(w => w.EffectiveBasePermissions);
 
             // Definition of no-script is not having the AddAndCustomizePages permission
             if (!web.EffectiveBasePermissions.Has(PermissionKind.AddAndCustomizePages))
@@ -1153,7 +1153,7 @@ namespace Microsoft.SharePoint.Client
         /// <param name="descriptionResource">Localized Description string</param>
         public static void SetLocalizationLabels(this Web web, string cultureName, string titleResource, string descriptionResource)
         {
-            web.EnsureProperty(w => w.TitleResource);
+            web.EnsureProperties(w => w.TitleResource);
 
             // Set translations for the culture
             web.TitleResource.SetValueForUICulture(cultureName, titleResource);
@@ -1392,7 +1392,7 @@ namespace Microsoft.SharePoint.Client
         public static Uri GetAppCatalog(this Web web)
         {
             var tenantSettings = TenantSettings.GetCurrent(web.Context);
-            tenantSettings.EnsureProperty(s => s.CorporateCatalogUrl);
+            tenantSettings.EnsureProperties(s => s.CorporateCatalogUrl);
             if(!string.IsNullOrEmpty(tenantSettings.CorporateCatalogUrl))
             {
                 return new Uri(tenantSettings.CorporateCatalogUrl);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/SharePointConnector.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/SharePointConnector.cs
@@ -413,7 +413,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
                 spFolder = cc.Web.RootFolder;
             }
 
-            spFolder.EnsureProperty(f => f.ServerRelativeUrl);
+            spFolder.EnsureProperties(f => f.ServerRelativeUrl);
 
             return UrlUtility.Combine(spFolder.ServerRelativeUrl, fileName);
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
@@ -36,7 +36,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             using (var scope = new PnPMonitoredScope(this.Name))
             {
-                web.EnsureProperty(w => w.ServerRelativeUrl);
+                web.EnsureProperties(w => w.ServerRelativeUrl);
 
                 // determine pages library
                 string pagesLibrary = "SitePages";

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -146,7 +146,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 #endif
                         if (file.WebParts != null && file.WebParts.Any())
                         {
-                            targetFile.EnsureProperty(f => f.ServerRelativeUrl);
+                            targetFile.EnsureProperties(f => f.ServerRelativeUrl);
 
                             var existingWebParts = web.GetWebParts(targetFile.ServerRelativeUrl).ToList();
                             foreach (var webPart in file.WebParts)

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -289,7 +289,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         private void ProcessFolders(Web web, TokenParser parser, PnPMonitoredScope scope, ListInfo list)
         {
-            list.SiteList.EnsureProperty(l => l.BaseType);
+            list.SiteList.EnsureProperties(l => l.BaseType);
             if ((list.SiteList.BaseType == BaseType.DocumentLibrary
                 || list.SiteList.BaseType == BaseType.GenericList)
                 && list.TemplateList.Folders != null && list.TemplateList.Folders.Count > 0)
@@ -1324,7 +1324,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 {
                     isDirty |= existingList.Set(x => x.IrmEnabled, templateList.IRMSettings.Enabled);
 
-                    existingList.EnsureProperty(l => l.InformationRightsManagementSettings);
+                    existingList.EnsureProperties(l => l.InformationRightsManagementSettings);
 
                     isDirty |= existingList.Set(x => x.InformationRightsManagementSettings.AllowPrint, templateList.IRMSettings.AllowPrint);
                     isDirty |= existingList.Set(x => x.InformationRightsManagementSettings.AllowScript, templateList.IRMSettings.AllowScript);
@@ -2396,7 +2396,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
                     if (siteList.BaseTemplate != (int)ListTemplateType.PictureLibrary)
                     {
-                        siteList.EnsureProperty(l => l.InformationRightsManagementSettings);
+                        siteList.EnsureProperties(l => l.InformationRightsManagementSettings);
                     }
 
                     if (creationInfo.PersistMultiLanguageResources)

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -30,7 +30,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 if (!template.Lists.Any()) return parser;
 
-                web.EnsureProperty(w => w.ServerRelativeUrl);
+                web.EnsureProperties(w => w.ServerRelativeUrl);
 
                 web.Context.Load(web.Lists, lc => lc.IncludeWithDefaultProperties(l => l.RootFolder.ServerRelativeUrl));
                 web.Context.ExecuteQueryRetry();
@@ -863,7 +863,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         private void ProcessFolderRow(Web web, ListItem listItem, List siteList, ListInstance listInstance, Model.Configuration.Lists.Lists.ExtractListsQueryConfiguration queryConfig, ProvisioningTemplate template, PnPMonitoredScope scope)
         {
-            listItem.EnsureProperty(it => it.ParentList.RootFolder.ServerRelativeUrl);
+            listItem.EnsureProperties(it => it.ParentList.RootFolder.ServerRelativeUrl);
             string serverRelativeListUrl = listItem.ParentList.RootFolder.ServerRelativeUrl;
             string folderPath = listItem.FieldValuesAsText["FileRef"].Substring(serverRelativeListUrl.Length).TrimStart(new char[] { '/' });
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
@@ -300,7 +300,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             //Test if fileuniqueid belongs to a folder
                             try
                             {
-                                web.EnsureProperty(w => w.ServerRelativeUrl);
+                                web.EnsureProperties(w => w.ServerRelativeUrl);
                                 string folderUrl = $"{web.ServerRelativeUrl}/{ match.Groups["fileurl"].Value}";
                                 var spFolder = web.GetFolderByServerRelativeUrl(folderUrl);
                                 web.Context.Load(spFolder, f => f.UniqueId);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -586,7 +586,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         private static void ClearExistingUsers(Group group)
         {
-            group.EnsureProperty(g => g.Users);
+            group.EnsureProperties(g => g.Users);
             while (group.Users.Count > 0)
             {
                 var user = group.Users[0];

--- a/Core/OfficeDevPnP.Core/Pages/ClientSidePage.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSidePage.cs
@@ -1124,7 +1124,7 @@ namespace OfficeDevPnP.Core.Pages
                     {
                         try
                         {
-                            this.Context.Site.EnsureProperty(p => p.Id);
+                            this.Context.Site.EnsureProperties(p => p.Id);
                             this.Context.Web.EnsureProperties(p => p.Id, p => p.Url);
 
                             var previewImage = this.Context.Web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(previewImageServerRelativeUrl));

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -1071,7 +1071,7 @@ namespace OfficeDevPnP.Core.Sites
         {
             string responseString = null;
 
-            context.Site.EnsureProperty(s => s.GroupId);
+            context.Site.EnsureProperties(s => s.GroupId);
 
             if (context.Web.IsSubSite())
             {


### PR DESCRIPTION
Reverts pnp/PnP-Sites-Core#2602 

running extraction of template showed this code to break:
 var iprFeature = features.GetById(featureID);
            iprFeature.EnsureProperty(f => f.DefinitionId);

Given we're releasing today, I'm reverting #2602 
