### PR TITLE
Handle special char in SiteTile beeing replaced by _ for SP-Groupnames

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/Functional/Implementation/CustomActionImplementation.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/Functional/Implementation/CustomActionImplementation.cs
@@ -22,6 +22,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Functional.Implementation
                 // Ensure the needed tokens are added to the target token parser, this is needed due to the tokenparser perf optimalizations
                 result.TargetTokenParser.Tokens.Add(new SiteToken(cc.Web));
                 result.TargetTokenParser.Tokens.Add(new SiteTitleToken(cc.Web));
+                result.TargetTokenParser.Tokens.Add(new GroupSiteTitleToken(cc.Web));
 
                 Assert.IsTrue(CustomActionValidator.Validate(result.SourceTemplate.CustomActions, result.TargetTemplate.CustomActions, result.TargetTokenParser, cc.Web));
 
@@ -31,6 +32,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Functional.Implementation
                 // Ensure the needed tokens are added to the target token parser, this is needed due to the tokenparser perf optimalizations
                 result2.TargetTokenParser.Tokens.Add(new SiteToken(cc.Web));
                 result2.TargetTokenParser.Tokens.Add(new SiteTitleToken(cc.Web));
+                result2.TargetTokenParser.Tokens.Add(new GroupSiteTitleToken(cc.Web));
 
                 Assert.IsTrue(CustomActionValidator.Validate(result2.SourceTemplate.CustomActions, result2.TargetTemplate.CustomActions, result2.TargetTokenParser, cc.Web));
 
@@ -39,6 +41,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Functional.Implementation
                 // Ensure the needed tokens are added to the target token parser, this is needed due to the tokenparser perf optimalizations
                 result3.TargetTokenParser.Tokens.Add(new SiteToken(cc.Web));
                 result3.TargetTokenParser.Tokens.Add(new SiteTitleToken(cc.Web));
+                result3.TargetTokenParser.Tokens.Add(new GroupSiteTitleToken(cc.Web));
 
                 Assert.IsTrue(CustomActionValidator.Validate(result3.SourceTemplate.CustomActions, result3.TargetTemplate.CustomActions, result3.TargetTokenParser, cc.Web));
 #endif
@@ -57,6 +60,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Functional.Implementation
                 // Ensure the needed tokens are added to the target token parser, this is needed due to the tokenparser perf optimalizations
                 result.TargetTokenParser.Tokens.Add(new SiteToken(cc.Web));
                 result.TargetTokenParser.Tokens.Add(new SiteTitleToken(cc.Web));
+                result.TargetTokenParser.Tokens.Add(new GroupSiteTitleToken(cc.Web));
 
                 Assert.IsTrue(CustomActionValidator.ValidateCustomActions(result.SourceTemplate.CustomActions.WebCustomActions, result.TargetTemplate.CustomActions.WebCustomActions, result.TargetTokenParser, cc.Web));
 
@@ -66,6 +70,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Functional.Implementation
                 // Ensure the needed tokens are added to the target token parser, this is needed due to the tokenparser perf optimalizations
                 result2.TargetTokenParser.Tokens.Add(new SiteToken(cc.Web));
                 result2.TargetTokenParser.Tokens.Add(new SiteTitleToken(cc.Web));
+                result2.TargetTokenParser.Tokens.Add(new GroupSiteTitleToken(cc.Web));
 
                 Assert.IsTrue(CustomActionValidator.ValidateCustomActions(result2.SourceTemplate.CustomActions.WebCustomActions, result2.TargetTemplate.CustomActions.WebCustomActions, result2.TargetTokenParser, cc.Web));
 #endif

--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectSiteSecurityTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectSiteSecurityTests.cs
@@ -310,9 +310,9 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 // default groups created during site creation assigned as associated owner group,
                 // associated member group, and associated visitor group.
                 // This is a prerequisite for the site collection used for unit testing purposes.                
-                Assert.IsTrue(template.Security.AssociatedOwnerGroup.Contains("{sitetitle}"), "Associated owner group title does not contain the Site Title token.");
-                Assert.IsTrue(template.Security.AssociatedMemberGroup.Contains("{sitetitle}"), "Associated owner group title does not contain the Site Title token.");
-                Assert.IsTrue(template.Security.AssociatedVisitorGroup.Contains("{sitetitle}"), "Associated owner group title does not contain the Site Title token.");
+                Assert.IsTrue(template.Security.AssociatedOwnerGroup.Contains("{groupsitetitle}"), "Associated owner group title does not contain the Group Site Title token.");
+                Assert.IsTrue(template.Security.AssociatedMemberGroup.Contains("{groupsitetitle}"), "Associated owner group title does not contain the Group Site Title token.");
+                Assert.IsTrue(template.Security.AssociatedVisitorGroup.Contains("{groupsitetitle}"), "Associated owner group title does not contain the Group Site Title token.");
             }
         }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -735,9 +735,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 var visitors = new List<User>();
                 var siteSecurity = new SiteSecurity();
 
+                string groupSiteTitle = System.Text.RegularExpressions.Regex.Replace(web.Title, "[\"/\\[\\]\\\\:|<>+=;,?*\'@]", "_");
+
                 if (!ownerGroup.ServerObjectIsNull.Value)
                 {
-                    siteSecurity.AssociatedOwnerGroup = ownerGroup.Title.Replace(web.Title, "{sitetitle}");
+                    siteSecurity.AssociatedOwnerGroup = ownerGroup.Title.Replace(groupSiteTitle, "{groupsitetitle}");
                     associatedGroupIds.Add(ownerGroup.Id);
                     foreach (var member in ownerGroup.Users)
                     {
@@ -746,7 +748,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 if (!memberGroup.ServerObjectIsNull.Value)
                 {
-                    siteSecurity.AssociatedMemberGroup = memberGroup.Title.Replace(web.Title, "{sitetitle}");
+                    siteSecurity.AssociatedMemberGroup = memberGroup.Title.Replace(groupSiteTitle, "{groupsitetitle}");
                     associatedGroupIds.Add(memberGroup.Id);
                     foreach (var member in memberGroup.Users)
                     {
@@ -755,7 +757,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 if (!visitorGroup.ServerObjectIsNull.Value)
                 {
-                    siteSecurity.AssociatedVisitorGroup = visitorGroup.Title.Replace(web.Title, "{sitetitle}");
+                    siteSecurity.AssociatedVisitorGroup = visitorGroup.Title.Replace(groupSiteTitle, "{groupsitetitle}");
                     associatedGroupIds.Add(visitorGroup.Id);
                     foreach (var member in visitorGroup.Users)
                     {
@@ -809,7 +811,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             scope.LogDebug("Processing group {0}", group.Title);
                             var siteGroup = new SiteGroup()
                             {
-                                Title = !string.IsNullOrEmpty(web.Title) ? group.Title.Replace(web.Title, "{sitename}") : group.Title,
+                                Title = !string.IsNullOrEmpty(web.Title) ? group.Title.Replace(groupSiteTitle, "{groupsitename}") : group.Title,
                                 AllowMembersEditMembership = group.AllowMembersEditMembership,
                                 AutoAcceptRequestToJoinLeave = group.AutoAcceptRequestToJoinLeave,
                                 AllowRequestToJoinLeave = group.AllowRequestToJoinLeave,
@@ -958,7 +960,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
             if (!string.IsNullOrEmpty(web.Title))
             {
-                loginName = loginName.Replace(web.Title, "{sitename}");
+                loginName = loginName.Replace(System.Text.RegularExpressions.Regex.Replace(web.Title, "[\"/\\[\\]\\\\:|<>+=;,?*\'@]", "_"), "{groupsitename}"); 
             }
             return loginName;
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/GroupSiteTitleToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/GroupSiteTitleToken.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Microsoft.SharePoint.Client;
+using OfficeDevPnP.Core.Attributes;
+
+namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
+{
+
+    [TokenDefinitionDescription(
+      Token = "{groupsitename}",
+      Description = "Returns the title of the current site with special char \" / \\ [ ] : | < > + = ; , ? * ' @ replaced with _",
+      Example = "{groupsitename}",
+      Returns = "Titel with replaced special char")]
+    internal class GroupSiteTitleToken : VolatileTokenDefinition
+    {
+        public GroupSiteTitleToken(Web web) : base(web, "{groupsitetitle}", "{groupsitename}")
+        {
+        }
+
+        public override string GetReplaceValue()
+        {
+            if (CacheValue == null)
+            {
+                TokenContext.Load(TokenContext.Web, w => w.Title);
+                TokenContext.ExecuteQueryRetry();
+                CacheValue = Regex.Replace(TokenContext.Web.Title, "[\"/\\[\\]\\\\:|<>+=;,?*\'@]", "_"); 
+            }
+            return CacheValue;
+        }
+    }
+
+}

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -190,6 +190,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 _tokens.Add(new SiteOwnerToken(web));
             if (tokenIds.Contains("sitetitle") || tokenIds.Contains("sitename"))
                 _tokens.Add(new SiteTitleToken(web));
+            if (tokenIds.Contains("groupsitetitle") || tokenIds.Contains("groupsitename"))
+                _tokens.Add(new GroupSiteTitleToken(web));
             if (tokenIds.Contains("associatedownergroupid"))
                 _tokens.Add(new AssociatedGroupIdToken(web, AssociatedGroupIdToken.AssociatedGroupType.owners));
             if (tokenIds.Contains("associatedmembergroupid"))

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -715,6 +715,7 @@
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\EveryoneToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\EveryoneButExternalUsersToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\FieldIdToken.cs" />
+    <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\GroupSiteTitleToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\ListContentTypeIdToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\O365GroupIdToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\SequenceSiteGroupIdToken.cs" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | yes
| Related issues?  | mentioned in #2609

What's in this Pull Request?
as agreed this fix implements 2 new tokens groupsitetitle and groupsitename and makes use of this new Tokens while extract the Site Groups and Roles. This tokens represent the sitetitle with special char " / \ [ ] : | < > + = ; , ? * ' @ replaced with _.