### PR TITLE
Fix ExtractClientSidePage check isNews when PromotedState is null

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
@@ -70,7 +70,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                         pageContentTypeId = GetParentIdValue(pageContentTypeId);
                     }
 
-                    var isNews = pageToExtract.LayoutType != Pages.ClientSidePageLayoutType.Home && int.Parse(pageToExtract.PageListItem[OfficeDevPnP.Core.Pages.ClientSidePage.PromotedStateField].ToString()) == (int)Pages.PromotedState.Promoted;
+                    int promotedState = 0;
+                    if(pageToExtract.PageListItem[OfficeDevPnP.Core.Pages.ClientSidePage.PromotedStateField]!=null)
+                    {
+                        int.TryParse(pageToExtract.PageListItem[OfficeDevPnP.Core.Pages.ClientSidePage.PromotedStateField].ToString(), out promotedState);
+                    }
+
+                    var isNews = pageToExtract.LayoutType != Pages.ClientSidePageLayoutType.Home && promotedState == (int)Pages.PromotedState.Promoted;
 
                     // Create the page;
                     BaseClientSidePage extractedPageInstance;

--- a/Core/OfficeDevPnP.Core/Pages/ClientSidePage.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSidePage.cs
@@ -968,9 +968,10 @@ namespace OfficeDevPnP.Core.Pages
 #endif
                     )
                 {
-                    item[ClientSidePage.PromotedStateField] = (Int32)PromotedState.NotPromoted;
                     item[ClientSidePage.BannerImageUrl] = "/_layouts/15/images/sitepagethumbnail.png";
                 }
+
+                item[ClientSidePage.PromotedStateField] = (Int32)PromotedState.NotPromoted;
                 item.UpdateOverwriteVersion();
                 this.Context.Web.Context.Load(item);
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Since about one week ms seems not to set promoted state to 0 but leave it null. The fix interprets null as promotedstate 0.