### PR TITLE
Fixing NullReferenceException in case the authentication with credentials fails

### DIFF
--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -703,6 +703,10 @@ namespace OfficeDevPnP.Core
             });
 
             JObject jobject = JObject.Parse(result);
+
+            // Ensure the resulting JSON could be parsed and that it doesn't contain an error. If incorrect credentials have been provided, this will not be the case and we return NULL to indicate not to have an access token.
+            if (jobject == null || jobject["error"] != null) return null;
+
             var token = jobject["access_token"].Value<string>();
             return token;
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

Fixing NullReferenceException in case the authentication with credentials fails, such as in the scenario where a user enters incorrect credentials. Returning NULL instead to indicate we don't have an AccessToken. 