### PR TITLE
Remove tokens from TokenDictionary and ListTokenDictionary when rebui…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -646,11 +646,22 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             web.EnsureProperties(w => w.ServerRelativeUrl, w => w.Language);
 
-            _tokens.RemoveAll(t => t.GetType() == typeof(ListIdToken));
-            _tokens.RemoveAll(t => t.GetType() == typeof(ListUrlToken));
-            _tokens.RemoveAll(t => t.GetType() == typeof(ListViewIdToken));
-            _tokens.RemoveAll(t => t.GetType() == typeof(ListContentTypeIdToken));
-            
+            //Remove tokens from TokenDictionary and ListTokenDictionary
+            Predicate<TokenDefinition> listTokenTypes = t => (t.GetType() == typeof(ListIdToken) || t.GetType() == typeof(ListUrlToken) || t.GetType() == typeof(ListViewIdToken) || t.GetType() == typeof(ListContentTypeIdToken));
+            foreach (var listToken in _tokens.FindAll(listTokenTypes))
+            {
+                foreach (string token in listToken.GetTokens())
+                {
+                    var tokenKey = Regex.Unescape(token);
+                    TokenDictionary.Remove(tokenKey);
+                    if (listToken is ListIdToken)
+                    {
+                        ListTokenDictionary.Remove(tokenKey);
+                    }
+                }
+            }
+            _tokens.RemoveAll(listTokenTypes);
+
             web.Context.Load(web.Lists, ls => ls.Include(l => l.Id, l => l.Title, l => l.RootFolder.ServerRelativeUrl, l => l.Views, l => l.ContentTypes
 #if !SP2013
             , l => l.TitleResource


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

We should remove tokens from TokenDictionary and ListTokenDictionary when rebuilding list tokens in the function RebuildListTokens. As there may be redundant tokens in the dictionary.

#### Steps to Reproduce
The issue can be reproduced by the following steps.

1. Use GetProvisioningTemplate to create a template at web level (change the scope to Web) which contains,

- An Events webpart on home page (connected to the events list).
- An events list in this web.

2. Use ApplyProvisioningTemplate to apply this template to the root site of a new site collection.
3. Use ApplyProvisioningTemplate to apply this template to the sub-site of the site collection.

The Events webpart at the sub-site level doesn't connect to the events list.