### PR TITLE
Added option to retrieve AAD user by its UPN optionally with specific properties

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Graph/GraphHttpClient.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Graph/GraphHttpClient.cs
@@ -1,13 +1,6 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
-using System.Threading.Tasks;
-using System.Web;
 
 namespace OfficeDevPnP.Core.Framework.Graph
 {

--- a/Core/OfficeDevPnP.Core/Framework/Graph/Model/User.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Graph/Model/User.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace OfficeDevPnP.Core.Framework.Graph.Model
@@ -62,6 +63,12 @@ namespace OfficeDevPnP.Core.Framework.Graph.Model
         /// Unique identifier of the user
         /// </summary>
         public Guid? Id { get; set; }
+
+        /// <summary>
+        /// Indicates if the account is currently enabled
+        /// </summary>
+        [JsonProperty("accountEnabled", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? AccountEnabled { get; set; }
 
         /// <summary>
         /// Additional properties requested regarding the user and included in the response

--- a/Core/OfficeDevPnP.Core/Framework/Graph/Model/User.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Graph/Model/User.cs
@@ -11,7 +11,7 @@ namespace OfficeDevPnP.Core.Framework.Graph.Model
         /// <summary>
         /// Business phone numbers for the user
         /// </summary>
-        public List<string> BusinessPhones { get; set; }
+        public IEnumerable<string> BusinessPhones { get; set; }
 
         /// <summary>
         /// Display name for the user
@@ -62,5 +62,10 @@ namespace OfficeDevPnP.Core.Framework.Graph.Model
         /// Unique identifier of the user
         /// </summary>
         public Guid? Id { get; set; }
+
+        /// <summary>
+        /// Additional properties requested regarding the user and included in the response
+        /// </summary>
+        public IDictionary<string, object> AdditionalProperties { get; set; }
     }
 }

--- a/Core/OfficeDevPnP.Core/Framework/Graph/Model/UserDelta.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Graph/Model/UserDelta.cs
@@ -1,0 +1,29 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace OfficeDevPnP.Core.Framework.Graph.Model
+{
+    /// <summary>
+    /// Defines a Microsoft Graph user delta
+    /// </summary>
+    public class UserDelta
+    {
+        /// <summary>
+        /// User objects with changes or all users if no SkipToken has been provided
+        /// </summary>
+        [JsonProperty("value", NullValueHandling = NullValueHandling.Ignore)]
+        public IList<User> Users { get; set; }
+
+        /// <summary>
+        /// The DeltaToken which can be used when querying for changes to request changes made to User objects since this DeltaToken has been given out
+        /// </summary>
+        [JsonProperty("@odata.deltaLink", NullValueHandling = NullValueHandling.Ignore)]
+        public string DeltaToken { get; set; }
+
+        /// <summary>
+        /// The NextLink which indicates there are more results
+        /// </summary>
+        [JsonProperty("@odata.nextLink", NullValueHandling = NullValueHandling.Ignore)]
+        public string NextLink { get; set; }
+    }
+}

--- a/Core/OfficeDevPnP.Core/Framework/Graph/UsersUtility.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Graph/UsersUtility.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 using Microsoft.Graph;
 using OfficeDevPnP.Core.Diagnostics;
 using System.Linq;
+using Newtonsoft.Json;
+using System.Web;
 
 namespace OfficeDevPnP.Core.Framework.Graph
 {
@@ -154,6 +156,97 @@ namespace OfficeDevPnP.Core.Framework.Graph
                 throw;
             }
             return result;
+        }
+
+        /// <summary>
+        /// Returns the users delta in the current domain filtered out with a custom OData filter. If no <paramref name="deltaToken"/> has been provided, all users will be returned with a deltatoken for a next run. If a <paramref name="deltaToken"/> has been provided, all users which were modified after the deltatoken has been generated will be returned.
+        /// </summary>
+        /// <param name="accessToken">The OAuth 2.0 Access Token to use for invoking the Microsoft Graph</param>
+        /// <param name="deltaToken">DeltaToken to indicate requesting changes since this deltatoken has been created. Leave NULL to retrieve all users with a deltatoken to use for subsequent queries.</param>
+        /// <param name="filter">OData filter to apply to retrieval of the users from the Microsoft Graph</param>
+        /// <param name="orderby">OData orderby instruction</param>
+        /// <param name="selectProperties">Allows providing the names of properties to return regarding the users. If not provided, the standard properties will be returned.</param>
+        /// <param name="startIndex">First item in the results returned by Microsoft Graph to return</param>
+        /// <param name="endIndex">Last item in the results returned by Microsoft Graph to return</param>
+        /// <param name="retryCount">Number of times to retry the request in case of throttling</param>
+        /// <param name="delay">Milliseconds to wait before retrying the request. The delay will be increased (doubled) every retry.</param>
+        /// <returns>List with User objects</returns>
+        public static Model.UserDelta ListUserDelta(string accessToken, string deltaToken, string filter, string orderby, string[] selectProperties = null, int startIndex = 0, int endIndex = 999, int retryCount = 10, int delay = 500)
+        {
+            if (String.IsNullOrEmpty(accessToken))
+            {
+                throw new ArgumentNullException(nameof(accessToken));
+            }
+
+            Model.UserDelta userDelta = new Model.UserDelta
+            {
+                Users = new List<Model.User>()
+            };
+            try
+            {
+                // GET https://graph.microsoft.com/v1.0/users/delta
+                string getUserDeltaUrl = $"{GraphHttpClient.MicrosoftGraphV1BaseUri}users/delta?";
+
+                if(selectProperties != null)
+                {
+                    getUserDeltaUrl += $"$select={string.Join(",", selectProperties)}&";
+                }
+                if(!string.IsNullOrEmpty(filter))
+                {
+                    getUserDeltaUrl += $"$filter={filter}&";
+                }
+                if(!string.IsNullOrEmpty(deltaToken))
+                {
+                    getUserDeltaUrl += $"$deltatoken={deltaToken}&";
+                }
+                if (!string.IsNullOrEmpty(orderby))
+                {
+                    getUserDeltaUrl += $"$orderby={orderby}&";
+                }
+
+                getUserDeltaUrl = getUserDeltaUrl.TrimEnd('&').TrimEnd('?');
+
+                int currentIndex = 0;
+
+                while (true)
+                {
+                    var response = GraphHttpClient.MakeGetRequestForString(
+                        requestUrl: getUserDeltaUrl,
+                        accessToken: accessToken);
+
+                    var userDeltaResponse = JsonConvert.DeserializeObject<Model.UserDelta>(response);
+
+                    if(!string.IsNullOrEmpty(userDeltaResponse.DeltaToken))
+                    {
+                        userDelta.DeltaToken = HttpUtility.ParseQueryString(new Uri(userDeltaResponse.DeltaToken).Query).Get("$deltatoken");
+                    }
+
+                    foreach (var user in userDeltaResponse.Users)
+                    {
+                        currentIndex++;
+
+                        if (currentIndex >= startIndex && currentIndex <= endIndex)
+                        {
+                            userDelta.Users.Add(user);
+                        }
+                    }
+                        
+                    if (userDeltaResponse.NextLink != null && currentIndex < endIndex)
+                    {
+                        getUserDeltaUrl = userDeltaResponse.NextLink;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+            catch (ServiceException ex)
+            {
+                Log.Error(Constants.LOGGING_SOURCE, CoreResources.GraphExtensions_ErrorOccured, ex.Error.Message);
+                throw;
+            }
+            return userDelta;
         }
     }
 }

--- a/Core/OfficeDevPnP.Core/Framework/Graph/UsersUtility.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Graph/UsersUtility.cs
@@ -28,6 +28,21 @@ namespace OfficeDevPnP.Core.Framework.Graph
         }
 
         /// <summary>
+        /// Returns the user with the provided <paramref name="userPrincipalName"/> from Azure Active Directory
+        /// </summary>
+        /// <param name="accessToken">The OAuth 2.0 Access Token to use for invoking the Microsoft Graph</param>
+        /// <param name="userPrincipalName">The User Principal Name of the user in Azure Active Directory to return</param>        
+        /// <param name="startIndex">First item in the results returned by Microsoft Graph to return</param>
+        /// <param name="endIndex">Last item in the results returned by Microsoft Graph to return</param>
+        /// <param name="retryCount">Number of times to retry the request in case of throttling</param>
+        /// <param name="delay">Milliseconds to wait before retrying the request. The delay will be increased (doubled) every retry.</param>
+        /// <returns>User object</returns>
+        public static Model.User GetUser(string accessToken, string userPrincipalName, int startIndex = 0, int endIndex = 999, int retryCount = 10, int delay = 500)
+        {
+            return ListUsers(accessToken, $"userPrincipalName eq '{userPrincipalName}'", null, startIndex, endIndex, retryCount, delay).FirstOrDefault();
+        }
+
+        /// <summary>
         /// Returns all the Users in the current domain
         /// </summary>
         /// <param name="accessToken">The OAuth 2.0 Access Token to use for invoking the Microsoft Graph</param>        

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -530,6 +530,7 @@
     <Compile Include="Framework\Graph\Model\GroupCreationRequest.cs" />
     <Compile Include="Framework\Graph\Model\SiteClassificationsSettings.cs" />
     <Compile Include="Framework\Graph\Model\User.cs" />
+    <Compile Include="Framework\Graph\Model\UserDelta.cs" />
     <Compile Include="Framework\Graph\UsersUtility.cs" />
     <Compile Include="Framework\Provisioning\CanProvisionRules\CanProvisionIssueTags.cs" />
     <Compile Include="Framework\Provisioning\CanProvisionRules\CanProvisionRuleAttribute.cs" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no 
| New feature?    | yes
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

Added option to retrieve Azure Active Directory user by its user principal name optionally allowing specific properties to be returned which is useful in i.e. the scenario where you want to retrieve extension attributes.

Also added the ability to retrieve user deltas to specifically get all changes to user objects in AAD since a provided deltatoken has been generated.