### PR TITLE
Fix *-PnPProvisioningTemplate Cmdlets not working with Windows Auth and a multiple Auth Providers WebApp

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
@@ -319,6 +319,16 @@ namespace Microsoft.SharePoint.Client
             if (clientContext.Credentials != null)
             {
                 clonedClientContext.Credentials = clientContext.Credentials;
+
+                // In case of existing Event Handlers
+                clonedClientContext.ExecutingWebRequest += (sender, webRequestEventArgs) =>
+                {
+                    // Call the ExecutingWebRequest delegate method from the original ClientContext object, but pass along the webRequestEventArgs of 
+                    // the new delegate method
+                    MethodInfo methodInfo = clientContext.GetType().GetMethod("OnExecutingWebRequest", BindingFlags.Instance | BindingFlags.NonPublic);
+                    object[] parametersArray = new object[] { webRequestEventArgs };
+                    methodInfo.Invoke(clientContext, parametersArray);
+                };
             }
             else
             {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #2645 

#### What's in this Pull Request?

This PR includes code to reattach eventhandlers onto copies ClientContext objects to ensure eventhandlers stay active even when using *-PnPProvisioningTemplate cmdlets.
