### PR TITLE
Include Default ListFields if they are Pinned/Showed in FiltersPane or have CustomFormatter set 

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -2601,13 +2601,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 var siteContext = web.Context.GetSiteCollectionContext();
                 var rootWeb = siteContext.Site.RootWeb;
                 siteColumns = rootWeb.Fields;
-                siteContext.Load(siteColumns, scs => scs.Include(sc => sc.Id, sc => sc.DefaultValue));
+                siteContext.Load(siteColumns, scs => scs.Include(sc => sc.Id, sc => sc.DefaultValue, sc => sc.PinnedToFiltersPane, sc => sc.ShowInFiltersPane, sc => sc.CustomFormatter));
                 siteContext.ExecuteQueryRetry();
             }
             else
             {
                 siteColumns = web.Fields;
-                web.Context.Load(siteColumns, scs => scs.Include(sc => sc.Id, sc => sc.DefaultValue));
+                web.Context.Load(siteColumns, scs => scs.Include(sc => sc.Id, sc => sc.DefaultValue, sc => sc.PinnedToFiltersPane, sc => sc.ShowInFiltersPane, sc => sc.CustomFormatter));
                 web.Context.ExecuteQueryRetry();
             }
 
@@ -2615,8 +2615,20 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             foreach (var field in fieldsToProcess)
             {
+                bool includeAsListField = false;
                 var siteColumn = siteColumns.FirstOrDefault(sc => sc.Id == field.Id);
-                if (siteColumn != null)
+                if(siteColumn != null)
+                {
+                    //include the list field if settings on List field instance are different then the ones on the web field
+                    if(siteColumn.PinnedToFiltersPane != field.PinnedToFiltersPane 
+                        || siteColumn.ShowInFiltersPane != field.ShowInFiltersPane 
+                        || siteColumn.CustomFormatter != field.CustomFormatter)
+                    {
+                        includeAsListField = true;
+                    }
+                }
+
+                if (siteColumn != null && !includeAsListField)
                 {
                     var addField = true;
                     if (siteList.ContentTypesEnabled && contentTypeFields.FirstOrDefault(c => c.Id == field.Id) == null)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Since Default Fields on Lists are usually not exported, we lose the Information if they have PinnedToFiltersPane=true or ShowInFiltersPane=true or CustomFormatter beeing set.
This fix makes sure that we export the Field if one of above is true in order to persist this settings.