### PR TITLE
ClientSidePageContent/ExtractObject - the Url for SitePages Library was wrong for Root (//SitePages)

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectClientSidePageContents.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectClientSidePageContents.cs
@@ -55,8 +55,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 var clientSidePageContentsHelper = new ClientSidePageContentsHelper();
 
-                var baseUrl = web.EnsureProperty(w => w.ServerRelativeUrl) + "/SitePages/";
-
                 // Extract the Home Page
                 web.EnsureProperties(w => w.RootFolder.WelcomePage, w => w.ServerRelativeUrl, w => w.Url);
                 var homePageUrl = web.RootFolder.WelcomePage;
@@ -78,6 +76,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 if (sitePagesLibrary != null)
                 {
+                    var baseUrl = $"{sitePagesLibrary.RootFolder.ServerRelativeUrl}/";
+
                     var templateFolderName = OfficeDevPnP.Core.Pages.ClientSidePage.DefaultTemplatesFolder;// string.Empty;
                     var templateFolderString = sitePagesLibrary.GetPropertyBagValueString(TemplatesFolderGuid, null);
                     Guid.TryParse(templateFolderString, out Guid templateFolderGuid);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #2472

#### What's in this Pull Request?
The baseUrl for the Root Site would be //SitePages and therefore fail. Since we load the Library anyway we can take the Url from List RootFolder and add the trailing / for RegEx.