### PR TITLE
Add the possibility to have ContentTypes updated on existing Lists

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -116,7 +116,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             {
                                 scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_ListInstances_Updating_list__0_, templateList.Title);
                                 var existingList = web.Lists[index];
-                                var returnTuple = UpdateList(web, existingList, templateList, parser, scope, isNoScriptSite);
+                                var returnTuple = UpdateList(web, existingList, templateList, parser, scope, applyingInformation.UpdateContentTypeOnExistingLists, isNoScriptSite);
                                 var updatedList = returnTuple.Item1;
                                 parser = returnTuple.Item2;
                                 if (updatedList != null)
@@ -1208,7 +1208,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return fieldElement;
         }
 
-        private Tuple<List, TokenParser> UpdateList(Web web, List existingList, ListInstance templateList, TokenParser parser, PnPMonitoredScope scope, bool isNoScriptSite = false)
+        private Tuple<List, TokenParser> UpdateList(Web web, List existingList, ListInstance templateList, TokenParser parser, PnPMonitoredScope scope, bool UpdateContentTypeOnExistingLists = false, bool isNoScriptSite = false)
         {
             web.Context.Load(existingList,
                 l => l.Title,
@@ -1467,7 +1467,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     isDirty = false;
                 }
 
-                if (existingList.ContentTypesEnabled)
+                //it might make sense to update ContentType on existing list in case we want to add/refresh a ContentType even if users should not choose
+                if (existingList.ContentTypesEnabled|| UpdateContentTypeOnExistingLists)
                 {
                     ConfigureContentTypes(web, existingList, templateList, false, scope);
                 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateApplyingInformation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateApplyingInformation.cs
@@ -55,6 +55,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         public bool OverwriteSystemPropertyBagValues { get; set; }
 
         /// <summary>
+        /// If true the ContentTypes on a existing List will be updated or new ones added. Default is false to preserve existing behavior.
+        /// </summary>
+        public bool UpdateContentTypeOnExistingLists { get; set; }
+
+        /// <summary>
         /// If true, existing navigation nodes of the site (where applicable) will be cleared out before applying the navigation nodes from the template (if any). This setting will override any settings made in the template.
         /// </summary>
         public bool ClearNavigation { get; set; }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Added the Option UpdateContentTypeOnExistingLists to ProvisioningTemplateApplyingInformation in order to tell UpdateList that it can Update ContentTypes on existing Lists even the user can not select CT him self.