### PR TITLE
Feature: Added support for Sensitivity Label while creating modern sites

### DIFF
--- a/Core/OfficeDevPnP.Core/Sites/SiteCollectionCreationInformation.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollectionCreationInformation.cs
@@ -26,6 +26,11 @@ namespace OfficeDevPnP.Core.Sites
         /// The Guid of the hub site to be used. If specified will associate the communication site to the hub site
         /// </summary>
         public Guid HubSiteId { get; set; }
+        
+        /// <summary>
+        /// The Sensitivity label to use. For instance 'Top Secret'. See https://www.youtube.com/watch?v=NxvUXBiPFcw for more information.
+        /// </summary>
+        public string SensitivityLabel { get; set; }
 
         /// <summary>
         /// Default constructor
@@ -252,6 +257,11 @@ namespace OfficeDevPnP.Core.Sites
         /// The Guid of the hub site to be used. If specified will associate the modern team site to the hub site.
         /// </summary>
         public Guid HubSiteId { get; set; }
+
+        /// <summary>
+        /// The Sensitivity label to use. For instance 'Top Secret'. See https://www.youtube.com/watch?v=NxvUXBiPFcw for more information.
+        /// </summary>
+        public string SensitivityLabel { get; set; }
 
         public SiteCreationGroupInformation()
         {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

This PR adds support to add sensitivity labels while provisioning modern team (backed by M365 group) site and communication site.

Note: in the modern team sites, it takes around 1-2 hours before the label appears.