### PR TITLE
Avoided providing HubSiteId on new sitecollection creation if no HubSite has been provided

### DIFF
--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -226,7 +226,10 @@ namespace OfficeDevPnP.Core.Sites
                     {
                         creationOptionsValues.Add($"SPSiteLanguage:{siteCollectionCreationInformation.Lcid}");
                     }
-                    creationOptionsValues.Add($"HubSiteId:{siteCollectionCreationInformation.HubSiteId}");
+                    if (siteCollectionCreationInformation.HubSiteId != Guid.Empty)
+                    {
+                        creationOptionsValues.Add($"HubSiteId:{siteCollectionCreationInformation.HubSiteId}");
+                    }
                     if (sensitivityLabelExists && sensitivityLabelId != Guid.Empty)
                     {
                         creationOptionsValues.Add($"SensitivityLabel:{sensitivityLabelId}");


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no 
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

Avoided providing HubSiteId on new sitecollection creation if no HubSiteId has been provided. It causes unnecessary traffic over the wire and yields the same result as not providing at all.