### PR TITLE
Added option to provide a PreferredDataLocation for supporting multi-geo tenants

### DIFF
--- a/Core/OfficeDevPnP.Core/Enums/Office365Geography.cs
+++ b/Core/OfficeDevPnP.Core/Enums/Office365Geography.cs
@@ -1,0 +1,73 @@
+﻿namespace OfficeDevPnP.Core.Enums
+{
+    /// <summary>
+    /// Defines the codes of geographies in which there is Office 365 presence. Used for multi-geo enabled tenants. List with available geographies is available at https://docs.microsoft.com/office365/enterprise/multi-geo-add-group-with-pdl#geo-location-codes.
+    /// </summary>
+    public enum Office365Geography : short
+    {
+        /// <summary>
+        /// Asia-Pacific
+        /// </summary>
+        APC,
+
+        /// <summary>
+        /// Australia
+        /// </summary>
+        AUS,
+
+        /// <summary>
+        /// Canada
+        /// </summary>
+        CAN,
+
+        /// <summary>
+        /// Europe / Middle East / Africa
+        /// </summary>
+        EUR,
+
+        /// <summary>
+        /// France
+        /// </summary>
+        FRA,
+
+        /// <summary>
+        /// India
+        /// </summary>
+        IND,
+
+        /// <summary>
+        /// Japan
+        /// </summary>
+        JPN,
+
+        /// <summary>
+        /// Korea
+        /// </summary>
+        KOR,
+
+        /// <summary>
+        /// North America
+        /// </summary>
+        NAM,
+
+        /// <summary>
+        /// South Africa
+        /// </summary>
+        ZAF,
+
+        /// <summary>
+        /// Switzerland
+        /// </summary>
+        CHE,
+
+        /// <summary>
+        /// United Arab Emirates
+        /// </summary>
+        ARE,
+
+        /// <summary>
+        /// United Kingdom
+        /// </summary>
+        GRB
+    }
+}

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -486,6 +486,7 @@
     <Compile Include="Enums\AppCatalogScope.cs" />
     <Compile Include="Enums\GraphSubscriptionChangeType.cs" />
     <Compile Include="Enums\GraphSubscriptionTlsVersion.cs" />
+    <Compile Include="Enums\Office365Geography.cs" />
     <Compile Include="Enums\SharePointTheme.cs" />
     <Compile Include="Extensions\ClientContextExtensions.cs" />
     <Compile Include="Extensions\ClientObjectExtensions.cs" />

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -147,8 +147,8 @@ namespace OfficeDevPnP.Core.Sites
                 throw new Exception("App-Only is currently not supported, unless you provide a Microsoft Graph Access Token.");
             }
 
-            // Creating sites through the Microsoft Graph API is preffered. However, if we need to pass in a PreferredDataLocation, we need to use the SharePoint API still.
-            if (string.IsNullOrEmpty(graphAccessToken) || siteCollectionCreationInformation.PreferredDataLocation.HasValue)
+            // Creating sites through the Microsoft Graph API is preffered. However, if we need to pass in a PreferredDataLocation or a sensitivity label, we need to use the SharePoint API still.
+            if (string.IsNullOrEmpty(graphAccessToken) || siteCollectionCreationInformation.PreferredDataLocation.HasValue || !string.IsNullOrEmpty(siteCollectionCreationInformation.SensitivityLabel))
             {
                 // Use the regular REST API of SPO to create the modern Team Site
                 responseContext = await CreateTeamSiteViaSPOAsync(clientContext, siteCollectionCreationInformation, delayAfterCreation, maxRetryCount, noWait: noWait);

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -147,7 +147,8 @@ namespace OfficeDevPnP.Core.Sites
                 throw new Exception("App-Only is currently not supported, unless you provide a Microsoft Graph Access Token.");
             }
 
-            if (string.IsNullOrEmpty(graphAccessToken))
+            // Creating sites through the Microsoft Graph API is preffered. However, if we need to pass in a PreferredDataLocation, we need to use the SharePoint API still.
+            if (string.IsNullOrEmpty(graphAccessToken) || !string.IsNullOrEmpty(siteCollectionCreationInformation.PreferredDataLocation))
             {
                 // Use the regular REST API of SPO to create the modern Team Site
                 responseContext = await CreateTeamSiteViaSPOAsync(clientContext, siteCollectionCreationInformation, delayAfterCreation, maxRetryCount, noWait: noWait);
@@ -236,6 +237,10 @@ namespace OfficeDevPnP.Core.Sites
                     if (siteCollectionCreationInformation.Owners != null && siteCollectionCreationInformation.Owners.Length > 0)
                     {
                         optionalParams.Add("Owners", siteCollectionCreationInformation.Owners);
+                    }
+                    if (!string.IsNullOrEmpty(siteCollectionCreationInformation.PreferredDataLocation))
+                    {
+                        optionalParams.Add("PreferredDataLocation", siteCollectionCreationInformation.PreferredDataLocation);
                     }
                     payload.Add("optionalParams", optionalParams);
 

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -148,7 +148,7 @@ namespace OfficeDevPnP.Core.Sites
             }
 
             // Creating sites through the Microsoft Graph API is preffered. However, if we need to pass in a PreferredDataLocation, we need to use the SharePoint API still.
-            if (string.IsNullOrEmpty(graphAccessToken) || !string.IsNullOrEmpty(siteCollectionCreationInformation.PreferredDataLocation))
+            if (string.IsNullOrEmpty(graphAccessToken) || siteCollectionCreationInformation.PreferredDataLocation.HasValue)
             {
                 // Use the regular REST API of SPO to create the modern Team Site
                 responseContext = await CreateTeamSiteViaSPOAsync(clientContext, siteCollectionCreationInformation, delayAfterCreation, maxRetryCount, noWait: noWait);
@@ -238,9 +238,9 @@ namespace OfficeDevPnP.Core.Sites
                     {
                         optionalParams.Add("Owners", siteCollectionCreationInformation.Owners);
                     }
-                    if (!string.IsNullOrEmpty(siteCollectionCreationInformation.PreferredDataLocation))
+                    if (siteCollectionCreationInformation.PreferredDataLocation.HasValue)
                     {
-                        optionalParams.Add("PreferredDataLocation", siteCollectionCreationInformation.PreferredDataLocation);
+                        optionalParams.Add("PreferredDataLocation", siteCollectionCreationInformation.PreferredDataLocation.Value.ToString());
                     }
                     payload.Add("optionalParams", optionalParams);
 

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollectionCreationInformation.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollectionCreationInformation.cs
@@ -1,9 +1,5 @@
 ﻿#if !ONPREMISES
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace OfficeDevPnP.Core.Sites
 {
@@ -95,7 +91,6 @@ namespace OfficeDevPnP.Core.Sites
         /// </summary>
         public string Owner { get; set; }
 
-
         /// <summary>
         /// If set to true, file sharing for guest users will be allowed.
         /// </summary>
@@ -140,7 +135,7 @@ namespace OfficeDevPnP.Core.Sites
         /// <summary>
         /// The geography in which to create the site collection. Only applicable to multi-geo enabled tenants.
         /// </summary>
-        public string PreferredDataLocation { get; set; }
+        public Enums.Office365Geography? PreferredDataLocation { get; set; }
 
         public SiteCreationInformation()
         {
@@ -177,7 +172,6 @@ namespace OfficeDevPnP.Core.Sites
         {
         }
 
-
         /// <summary>
         /// TeamSiteCollectionTeamSiteCollectionGroupifyInformationCreationInformation constructor
         /// </summary>
@@ -187,7 +181,6 @@ namespace OfficeDevPnP.Core.Sites
         public TeamSiteCollectionGroupifyInformation(string alias, string displayName, string description = null) : base(alias, displayName, description)
         {
         }
-
     }
 
     /// <summary>
@@ -270,7 +263,7 @@ namespace OfficeDevPnP.Core.Sites
         /// <summary>
         /// The geography in which to create the site collection. Only applicable to multi-geo enabled tenants.
         /// </summary>
-        public string PreferredDataLocation { get; set; }
+        public Enums.Office365Geography? PreferredDataLocation { get; set; }
 
         public SiteCreationGroupInformation()
         {

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollectionCreationInformation.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollectionCreationInformation.cs
@@ -137,6 +137,10 @@ namespace OfficeDevPnP.Core.Sites
         /// </summary>
         public string WebTemplate { get; protected set; }
 
+        /// <summary>
+        /// The geography in which to create the site collection. Only applicable to multi-geo enabled tenants.
+        /// </summary>
+        public string PreferredDataLocation { get; set; }
 
         public SiteCreationInformation()
         {
@@ -262,6 +266,11 @@ namespace OfficeDevPnP.Core.Sites
         /// The Sensitivity label to use. For instance 'Top Secret'. See https://www.youtube.com/watch?v=NxvUXBiPFcw for more information.
         /// </summary>
         public string SensitivityLabel { get; set; }
+
+        /// <summary>
+        /// The geography in which to create the site collection. Only applicable to multi-geo enabled tenants.
+        /// </summary>
+        public string PreferredDataLocation { get; set; }
 
         public SiteCreationGroupInformation()
         {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | asked for in i.e. https://github.com/pnp/PnP-PowerShell/issues/2682

#### What's in this Pull Request?

Added PreferredDataLocation parameter to creating a new site which allows for specifying of a geographical region for multi-geo enabled tenants.

Also added fix for forcing sensitivitylabel to use the SharePoint API to create the site, otherwise the sensitivity label will not be applied.