### PR TITLE
Improve exception message when a file is not found during the provisioning

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ConnectorFileHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ConnectorFileHelper.cs
@@ -64,6 +64,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                 fileName = WebUtility.UrlDecode(fileName);
                 stream = connector.GetFileStream(fileName, container);
             }
+
+            if (stream == null)
+                throw new ArgumentException($"The specified filename '{fileName}' cannot be found");
+
             byte[] returnData;
 
             using (var memStream = new MemoryStream())


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | Improves #2613 

#### What's in this Pull Request?

Improve the exception message when a file is not found during the provisioning by throwing a detailed ArgumentException with the filename that was not found instead of throwing a NullDereferenceException.

Outcome without the fix:
![image](https://user-images.githubusercontent.com/1153754/84495146-f9960e00-acaa-11ea-8af0-cfb8b54d4e1d.png)

Outcome with the fix:
![image](https://user-images.githubusercontent.com/1153754/84495038-ceabba00-acaa-11ea-9002-fa91c0730f49.png)

