### PR TITLE
Fix for GetProvisioningTemplate and ApplyProvisioningTemplate to being stucked in Windows Forms applications.

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
@@ -707,6 +707,7 @@ namespace Microsoft.SharePoint.Client
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
+        //public static async Task<string> GetRequestDigest(this ClientContext context)
         public static async Task<string> GetRequestDigest(this ClientContext context)
         {
             await new SynchronizationContextRemover();
@@ -756,7 +757,7 @@ namespace Microsoft.SharePoint.Client
                 var contextInformation = JsonConvert.DeserializeObject<dynamic>(responseString);
 
                 string formDigestValue = contextInformation.d.GetContextWebInformation.FormDigestValue;
-                return await Task.Run(() => formDigestValue);
+                return await Task.Run(() => formDigestValue).ConfigureAwait(false);
             }
         }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/FileSystemConnector.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/FileSystemConnector.cs
@@ -383,6 +383,43 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             return filePath;
         }
 
+        private string ConstructPathFiles(string fileName, string container)
+        {
+            string filePath = "";
+
+            if (container.IndexOf(@"\") > 0)
+            {
+                string[] parts = container.Split(new string[] { @"\" }, StringSplitOptions.RemoveEmptyEntries);
+                filePath = Path.Combine(Path.GetDirectoryName(GetConnectionString()), parts[0]);
+
+                if (parts.Length > 1)
+                {
+                    for (int i = 1; i < parts.Length; i++)
+                    {
+                        filePath = Path.Combine(filePath, parts[i]);
+                    }
+                }
+
+                if (!String.IsNullOrEmpty(fileName))
+                {
+                    filePath = Path.Combine(filePath, fileName);
+                }
+            }
+            else
+            {
+                if (!String.IsNullOrEmpty(fileName))
+                {
+                    filePath = Path.Combine(Path.GetDirectoryName(GetConnectionString()), container, fileName);
+                }
+                else
+                {
+                    filePath = Path.Combine(Path.GetDirectoryName(GetConnectionString()), container);
+                }
+            }
+
+            return filePath;
+        }
+
         #endregion
     }
 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -118,7 +118,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     {
                         using (var stream = FileUtilities.GetFileStream(template, file))
                         {
-                            if (stream == null)
+                            if (stream == null && true)
                             {
                                 throw new FileNotFoundException($"File {file.Src} does not exist");
                             }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -118,7 +118,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     {
                         using (var stream = FileUtilities.GetFileStream(template, file))
                         {
-                            if (stream == null && true)
+                            if (stream == null)
                             {
                                 throw new FileNotFoundException($"File {file.Src} does not exist");
                             }

--- a/Core/OfficeDevPnP.Core/Utilities/RESTUtilities.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/RESTUtilities.cs
@@ -91,7 +91,9 @@ namespace OfficeDevPnP.Core.Utilities
                             handler.Credentials = networkCredential;
                         }
                     }
-                    request.Headers.Add("X-RequestDigest", await (web.Context as ClientContext).GetRequestDigest());
+
+                    var requestDigest = await (web.Context as ClientContext).GetRequestDigest().ConfigureAwait(false);
+                    request.Headers.Add("X-RequestDigest", requestDigest);
 
                     // Perform actual post operation
                     HttpResponseMessage response = await httpClient.SendAsync(request, new System.Threading.CancellationToken());
@@ -154,7 +156,8 @@ namespace OfficeDevPnP.Core.Utilities
                             handler.Credentials = networkCredential;
                         }
                     }
-                    request.Headers.Add("X-RequestDigest", await (web.Context as ClientContext).GetRequestDigest());
+                    var requestDigest = await (web.Context as ClientContext).GetRequestDigest().ConfigureAwait(false);
+                    request.Headers.Add("X-RequestDigest", requestDigest);
 
                     if (!string.IsNullOrEmpty(payload))
                     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes https://github.com/pnp/PnP-Sites-Core/issues/2564

#### What's in this Pull Request?

Small change in RESTUtilities.cs to set header correctly because sometimes the header had null value in Windows Forms application using this library, causing GetProvisioningTemplate and ApplyProvisioningTemplate methods to get stucked.

The change in ClientContextExtensions.cs I'm not really sure if it is necesary due to I didn't make more tests on this.