### PR TITLE
Fix incorrect onprem eventreceiver reference

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/ListExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ListExtensions.cs
@@ -1738,10 +1738,10 @@ namespace Microsoft.SharePoint.Client
                         EventReceiverDefinitionCreationInformation eventCi = new EventReceiverDefinitionCreationInformation();
                         eventCi.Synchronization = EventReceiverSynchronization.Synchronous;
                         eventCi.EventType = EventReceiverType.ItemAdded;
-#if !ONPREMISES
-                        eventCi.ReceiverAssembly = "Microsoft.Office.DocumentManagement, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
-#else
+#if SP2013
                         eventCi.ReceiverAssembly = "Microsoft.Office.DocumentManagement, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+#else
+                        eventCi.ReceiverAssembly = "Microsoft.Office.DocumentManagement, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
 #endif
                         eventCi.ReceiverClass = "Microsoft.Office.DocumentManagement.LocationBasedMetadataDefaultsReceiver";
                         eventCi.ReceiverName = "LocationBasedMetadataDefaultsReceiver ItemAdded";


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

Fixed incorrect location based metadata event receiver reference for SharePoint 2016 and 2019.
Previous version used a reference for SharePoint 2013 for SharePoint 2016 and 2019.
Assembly redirects added by default in SharePoint 2016 and 2019 installations probably made this not a real issue.