### PR TITLE
Call ParseString for webSettings.SearchCenterUrl

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
@@ -394,7 +394,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         web.SearchBoxInNavBar = (SearchBoxInNavBarType)Enum.Parse(typeof(SearchBoxInNavBarType), webSettings.SearchBoxInNavBar.ToString(), true);
                     }
 
-                    if (!string.IsNullOrEmpty(webSettings.SearchCenterUrl) &&
+                    string searchCenterUrl = parser.ParseString(webSettings.SearchCenterUrl);
+                    if (!string.IsNullOrEmpty(searchCenterUrl) &&
                         web.GetWebSearchCenterUrl(true) != webSettings.SearchCenterUrl)
                     {
                         web.SetWebSearchCenterUrl(webSettings.SearchCenterUrl);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |  yes
| New sample?      | no

#### What's in this Pull Request?

Call parse string from TokenParser for SearchCenterUrl property.