### PR TITLE
Adding authentication cookies for SPO Admin domain

### DIFF
--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -425,7 +425,10 @@ namespace OfficeDevPnP.Core
                         }
                         if (authCookies != null)
                         {
-                            authCookiesContainer.SetCookies(siteUri, string.Join(",", authCookies));
+                            // Set the authentication cookies both on the SharePoint Online Admin as well as on the SharePoint Online domains to allow for APIs on both domains to be used
+                            var authCookiesString = string.Join(",", authCookies);
+                            authCookiesContainer.SetCookies(siteUri, authCookiesString);
+                            authCookiesContainer.SetCookies(new Uri(siteUri.Scheme + "://" + siteUri.Authority.Replace(".sharepoint.com", "-admin.sharepoint.com")), authCookiesString);
                             form.Close();
                         }
                     }

--- a/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
@@ -312,7 +312,6 @@ namespace Microsoft.SharePoint.Client
             clonedClientContext.DisableReturnValueCache = clientContext.DisableReturnValueCache;
 #endif
 
-
             // In case of using networkcredentials in on premises or SharePointOnlineCredentials in Office 365
             if (clientContext.Credentials != null)
             {
@@ -330,7 +329,6 @@ namespace Microsoft.SharePoint.Client
             }
             else
             {
-
                 // Check if we do have context settings
                 var contextSettings = clientContext.GetContextSettings();
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | discussed in https://github.com/pnp/PnP-PowerShell/issues/2742

#### What's in this Pull Request?
In PnP PowerShell, when using `Connect-PnPOnline -Url https://tenant.sharepoint.com -WebLogin` and then running a PnPAdminCmdlet such as `Get-PnPTenant`, it would throw a 401 access denied as it doesn't have the FedAuth cookie for the tenant-admin.sharepoint.com domain. With this update, when connecting, it will add the FedAuth cookie for both the tenant.sharepoint.com as well as for the tenant-admin.sharepoint.com domains so the PnPAdminCmdlets will auto elevate and work correctly.