### PR TITLE
Update ObjectFiles.cs

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -182,13 +182,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
 #endif
                         
-                        //Set Properties before Checkin
-                        if (file.Properties != null && file.Properties.Any())
-                        {
-                            Dictionary<string, string> transformedProperties = file.Properties.ToDictionary(property => property.Key, property => parser.ParseString(property.Value));
-                            SetFileProperties(targetFile, transformedProperties, parser, false);
-                        }
-
                         switch (file.Level)
                         {
                             case Model.FileLevel.Published:
@@ -217,6 +210,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             (file.Security.ClearSubscopes == true || file.Security.CopyRoleAssignments == true || file.Security.RoleAssignments.Count > 0))
                         {
                             targetFile.ListItemAllFields.SetSecurity(parser, file.Security);
+                        }
+                        
+                        if (file.Properties != null && file.Properties.Any())	
+                        {	
+                            Dictionary<string, string> transformedProperties = file.Properties.ToDictionary(property => property.Key, property => parser.ParseString(property.Value));	
+                            SetFileProperties(targetFile, transformedProperties, parser, false);	
                         }
                     }
 


### PR DESCRIPTION
Setting properties before checking in causes an error. ref issue: #1831

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1831, mentioned in #2335

#### What's in this Pull Request?

Setting properties before checking in causes an error "The file is not checked out" when trying to set the webparts in a file while provisioning a pnp template. The fix was to move the update properties logic before the check in happens.