### PR TITLE
Minor fix: Made enum nullable for certain types of Teams

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/BaseTeam.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/BaseTeam.cs
@@ -31,7 +31,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model.Teams
         /// <summary>
         /// The Visibility for the Team
         /// </summary>
-        public TeamVisibility Visibility { get; set; }
+        public TeamVisibility? Visibility { get; set; }
 
         /// <summary>
         /// The Photo for the Team

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/Team.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/Team.cs
@@ -54,7 +54,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model.Teams
         /// </summary>
         public TeamAppInstanceCollection Apps { get; private set; }
 
-        public TeamSpecialization Specialization { get; set; }
+        public TeamSpecialization? Specialization { get; set; }
 
         /// <summary>
         /// Declares the ID of the targt Group/Team to update, optional attribute. Cannot be used together with CloneFrom.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

This minor PR makes the Teams specialization and visibility enums nullable to handle null while extraction.
Currently it gives error as 

`Error converting value {null} to type 'OfficeDevPnP.Core.Framework.Provisioning.Model.Teams.TeamSpecialization` and similar for visibility value as well.