### PR TITLE
Fixing SharePoint 2013 not returning any web parts

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/PageExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/PageExtensions.cs
@@ -417,6 +417,9 @@ namespace Microsoft.SharePoint.Client
                 {
                     request.UseDefaultCredentials = true;
                 }
+                
+                // apparently without a user agent SharePoint 2013 returns a 302 redirect to an error page without returning the actual web part
+                request.UserAgent = "Mozilla/5.0 (Windows NT; Windows NT 6.2; de-DE) ihateyousharepoint/5.1.19041.1";
 
                 var response = request.GetResponse();
                 using (Stream stream = response.GetResponseStream())


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | none that I know of

#### What's in this Pull Request?

This took a while to find. SharePoint apparently cannot export web parts via `exportwp.aspx` when the user agent is missing. 

Minimal PowerShell repro:

```powershell
$request = [System.Net.WebRequest]::CreateHttp('https://sharepointhost:443/hr/_vti_bin/exportwp.aspx?pageurl=https:%2F%2Fsharepointhost:443%2Fhr%2FSystemsites%2FHomepage.aspx&guidstring=c58a4115-542a-4f22-88a0-ae4e16e79877');
$request.Credentials = Get-Credential
$request.Method = 'GET';
#$request.UserAgent = "Mozilla/5.0 (Windows NT; Windows NT 6.2; de-DE) WindowsPowerShell/5.1.19041.1";
$request.GetResponse();
```
The response is a 302 redirect to `https://sharepointhost/hr/_layouts/15/error.aspx?ErrorText=Object reference not set to an instance of an object.`

Then try again with the user agent set and it works.

This is not cool, SharePoint.