### PR TITLE
Fixing handling of missing principal in site security handler

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -590,7 +590,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                         web.Context.ExecuteQueryRetry();
                                     } else
                                     {
-                                        WriteMessage($"Principal '${roleAssignment.Principal}' not found, cannot grant permissions", ProvisioningMessageType.Warning);
+                                        WriteMessage($"Principal '{roleAssignment.Principal}' not found, cannot grant permissions", ProvisioningMessageType.Warning);
                                     }
                                 }
                                 else
@@ -618,7 +618,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 }
                                 else
                                 {
-                                    WriteMessage($"Principal '${roleAssignment.Principal}' not found, cannot revoke permissions", ProvisioningMessageType.Warning);
+                                    WriteMessage($"Principal '{roleAssignment.Principal}' not found, cannot revoke permissions", ProvisioningMessageType.Warning);
                                 }
                             }
                         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -588,6 +588,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                         roleDefinitionBindingCollection.Add(roleDefinition);
                                         web.RoleAssignments.Add(principal, roleDefinitionBindingCollection);
                                         web.Context.ExecuteQueryRetry();
+                                    } else
+                                    {
+                                        WriteMessage($"Principal '${roleAssignment.Principal}' not found, cannot grant permissions", ProvisioningMessageType.Warning);
                                     }
                                 }
                                 else
@@ -612,6 +615,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                             break;
                                         }
                                     }
+                                }
+                                else
+                                {
+                                    WriteMessage($"Principal '${roleAssignment.Principal}' not found, cannot revoke permissions", ProvisioningMessageType.Warning);
                                 }
                             }
                         }
@@ -705,6 +712,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 catch (Exception ex)
                 {
                     scope.LogWarning(ex, "Failed to EnsureUser {0}", parsedRoleDefinition);
+                    principal = null;
                 }
             }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

Missing principals for direct role assignments on the site level are not handled properly as provisioning fails with an exception.

But the code looks like this wasn't the intention. Here's why:

The exception from `EnsureUser` is being caught:
https://github.com/pnp/PnP-Sites-Core/blob/dev/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs#L705-L708

The access to principal is guarded with `?`:
https://github.com/pnp/PnP-Sites-Core/blob/dev/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs#L711

And there are `null` checks in place like here:
https://github.com/pnp/PnP-Sites-Core/blob/dev/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs#L585

My addition ensures those null checks can do what they were designed for. And I added a warning for the user so they can check if this is ok that the principal is missing (for me this often is ok when moving stuff between slightly different tenants).