### PR TITLE
Checking for and ignore missing principals when provisioning object security

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
@@ -49,7 +49,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
                         // catch user not found
                         if (ex.ServerErrorCode == -2146232832 && ex.ServerErrorTypeName.Equals("Microsoft.SharePoint.SPException", StringComparison.InvariantCultureIgnoreCase))
                         {
-                            MessageDelegate($"Cannot find principal '${roleAssignmentPrincipal}', cannot grant permissions", ProvisioningMessageType.Warning);
+                            MessageDelegate($"Cannot find principal '{roleAssignmentPrincipal}', cannot grant permissions", ProvisioningMessageType.Warning);
                             continue;
                         }
                     }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
@@ -12,38 +12,64 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
 {
     internal static class SecurableObjectExtensions
     {
-        public static void SetSecurity(this SecurableObject securable, TokenParser parser, ObjectSecurity security)
+        private static Principal TryGetGroupPrincipal(IEnumerable<Microsoft.SharePoint.Client.Group> groups, string roleAssignmentPrincipal)
         {
-            // If there's no role assignments we're returning
-            if (security.RoleAssignments.Count == 0) return;
+            Principal principal = groups.FirstOrDefault(g => g.LoginName.Equals(roleAssignmentPrincipal, StringComparison.OrdinalIgnoreCase));
 
-            var context = securable.Context as ClientContext;
+            // Principal can be resolved via it's ID if an associatedgroupid token was used
+            if (principal == null)
+            {
+                if (Int32.TryParse(roleAssignmentPrincipal, out int roleAssignmentPrincipalId))
+                {
+                    principal = groups.FirstOrDefault(g => g.Id.Equals(roleAssignmentPrincipalId));
+                }
+            }
 
-            var groups = context.LoadQuery(context.Web.SiteGroups.Include(g => g.LoginName, g => g.Id));
-            var webRoleDefinitions = context.LoadQuery(context.Web.RoleDefinitions);
+            return principal;
+        }
 
-            securable.BreakRoleInheritance(security.CopyRoleAssignments, security.ClearSubscopes);
+        private static IEnumerable<Model.RoleAssignment> CheckForAndRemoveNonExistingPrincipals(IEnumerable<Model.RoleAssignment> RoleAssignments, TokenParser parser, IEnumerable<Microsoft.SharePoint.Client.Group> groups, ClientContext context, ProvisioningMessagesDelegate MessageDelegate)
+        {
+            var result = new List<Model.RoleAssignment>();
+            foreach (var roleAssignment in RoleAssignments)
+            {
+                var roleAssignmentPrincipal = parser.ParseString(roleAssignment.Principal);
 
-            var securableRoleAssignments = context.LoadQuery(securable.RoleAssignments);
-            context.ExecuteQueryRetry();
+                Principal principal = TryGetGroupPrincipal(groups, roleAssignmentPrincipal);
 
-            foreach (var roleAssignment in security.RoleAssignments)
+                if (principal == null)
+                {
+                    try
+                    {
+                        context.Web.EnsureUser(roleAssignmentPrincipal);
+                        context.ExecuteQueryRetry();
+                    }
+                    catch (ServerException ex)
+                    {
+                        // catch user not found
+                        if (ex.ServerErrorCode == -2146232832 && ex.ServerErrorTypeName.Equals("Microsoft.SharePoint.SPException", StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            MessageDelegate($"Cannot find principal '${roleAssignmentPrincipal}', cannot grant permissions", ProvisioningMessageType.Warning);
+                            continue;
+                        }
+                    }
+                }
+
+                result.Add(roleAssignment);
+            }
+            return result;
+        }
+
+        private static void ApplySecurity(SecurableObject securable, TokenParser parser, ClientContext context, IEnumerable<Microsoft.SharePoint.Client.Group> groups, IEnumerable<Microsoft.SharePoint.Client.RoleDefinition> webRoleDefinitions, IEnumerable<Microsoft.SharePoint.Client.RoleAssignment> securableRoleAssignments, IEnumerable<Model.RoleAssignment> roleAssignmentsToHandle)
+        {
+            foreach (var roleAssignment in roleAssignmentsToHandle)
             {
                 if (!roleAssignment.Remove)
                 {
                     var roleAssignmentPrincipal = parser.ParseString(roleAssignment.Principal);
 
-                    Principal principal = groups.FirstOrDefault(g => g.LoginName.Equals(roleAssignmentPrincipal, StringComparison.OrdinalIgnoreCase));
+                    Principal principal = TryGetGroupPrincipal(groups, roleAssignmentPrincipal);
 
-                    // Principal can be resolved via it's ID if an associatedgroupid token was used
-                    if (principal == null)
-                    {
-                        if (Int32.TryParse(roleAssignmentPrincipal, out int roleAssignmentPrincipalId))
-                        {
-                            principal = groups.FirstOrDefault(g => g.Id.Equals(roleAssignmentPrincipalId));
-                        }
-                    }
-                    
                     if (principal == null)
                     {
                         principal = context.Web.EnsureUser(roleAssignmentPrincipal);
@@ -62,20 +88,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
                             securable.RoleAssignments.Add(principal, roleDefinitionBindingCollection);
                         }
                     }
-                } else
+                }
+                else
                 {
                     var roleAssignmentPrincipal = parser.ParseString(roleAssignment.Principal);
 
-                    Principal principal = groups.FirstOrDefault(g => g.LoginName.Equals(roleAssignmentPrincipal, StringComparison.OrdinalIgnoreCase));
-
-                    // Principal can be resolved via it's ID if an associatedgroupid token was used
-                    if (principal == null)
-                    {
-                        if (Int32.TryParse(roleAssignmentPrincipal, out int roleAssignmentPrincipalId))
-                        {
-                            principal = groups.FirstOrDefault(g => g.Id.Equals(roleAssignmentPrincipalId));
-                        }
-                    }
+                    Principal principal = TryGetGroupPrincipal(groups, roleAssignmentPrincipal);
 
                     if (principal == null)
                     {
@@ -100,7 +118,42 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
                     }
                 }
             }
+        }
+
+        public static void SetSecurity(this SecurableObject securable, TokenParser parser, ObjectSecurity security, ProvisioningMessagesDelegate MessageDelegate)
+        {
+            // If there's no role assignments we're returning
+            if (security.RoleAssignments.Count == 0) return;
+
+            var context = securable.Context as ClientContext;
+
+            var groups = context.LoadQuery(context.Web.SiteGroups.Include(g => g.LoginName, g => g.Id));
+            var webRoleDefinitions = context.LoadQuery(context.Web.RoleDefinitions);
+
+            securable.BreakRoleInheritance(security.CopyRoleAssignments, security.ClearSubscopes);
+
+            var securableRoleAssignments = context.LoadQuery(securable.RoleAssignments);
             context.ExecuteQueryRetry();
+            IEnumerable<Model.RoleAssignment> roleAssignmentsToHandle = security.RoleAssignments;
+
+            // try to apply the security in two steps: step one assumes all principals from the template exist and can be granted permission at once
+            try
+            {
+                // note that this step fails if there is one principal that doesn't exist
+                ApplySecurity(securable, parser, context, groups, webRoleDefinitions, securableRoleAssignments, roleAssignmentsToHandle);
+                context.ExecuteQueryRetry();
+            }
+            catch (ServerException ex)
+            {
+                // catch user not found; enter step 2: check each and every principal for existence before granting security for those that exist
+                if (ex.ServerErrorCode == -2146232832 && ex.ServerErrorTypeName.Equals("Microsoft.SharePoint.SPException", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    roleAssignmentsToHandle = CheckForAndRemoveNonExistingPrincipals(roleAssignmentsToHandle, parser, groups, context, MessageDelegate);
+                    ApplySecurity(securable, parser, context, groups, webRoleDefinitions, securableRoleAssignments, roleAssignmentsToHandle);
+                    // if it fails this time we just let it fail
+                    context.ExecuteQueryRetry();
+                }
+            }
         }
 
         public static ObjectSecurity GetSecurity(this SecurableObject securable)

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -216,7 +216,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         if (file.Security != null &&
                             (file.Security.ClearSubscopes == true || file.Security.CopyRoleAssignments == true || file.Security.RoleAssignments.Count > 0))
                         {
-                            targetFile.ListItemAllFields.SetSecurity(parser, file.Security);
+                            targetFile.ListItemAllFields.SetSecurity(parser, file.Security, WriteMessage);
                         }
                     }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1538,7 +1538,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 if (templateList.Security != null)
                 {
-                    existingList.SetSecurity(parser, templateList.Security);
+                    existingList.SetSecurity(parser, templateList.Security, WriteMessage);
                 }
                 return Tuple.Create(existingList, parser);
             }
@@ -2082,7 +2082,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 #endif
             if (templateList.Security != null)
             {
-                createdList.SetSecurity(parser, templateList.Security);
+                createdList.SetSecurity(parser, templateList.Security, WriteMessage);
             }
             return Tuple.Create(createdList, parser);
         }
@@ -2222,7 +2222,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     var currentFolderItem = currentFolder.ListItemAllFields;
                     parentFolder.Context.Load(currentFolderItem);
                     parentFolder.Context.ExecuteQueryRetry();
-                    currentFolderItem.SetSecurity(parser, folder.Security);
+                    currentFolderItem.SetSecurity(parser, folder.Security, WriteMessage);
                 }
 
                 // Handle current folder property bags

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -181,7 +181,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     }
                                     if (dataRow.Security != null && (dataRow.Security.ClearSubscopes || dataRow.Security.CopyRoleAssignments || dataRow.Security.RoleAssignments.Count > 0))
                                     {
-                                        listitem.SetSecurity(parser, dataRow.Security);
+                                        listitem.SetSecurity(parser, dataRow.Security, WriteMessage);
                                     }
                                 }
                             }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
@@ -202,7 +202,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     {
                         web.Context.Load(file.ListItemAllFields);
                         web.Context.ExecuteQueryRetry();
-                        file.ListItemAllFields.SetSecurity(parser, page.Security);
+                        file.ListItemAllFields.SetSecurity(parser, page.Security, WriteMessage);
                     }
                 }
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes #2723

#### What's in this Pull Request?

Unfortunately some lines of code had to be changed to achieve what I described in #2723. It looks bigger than it actually is because the diff view seems to be confused by the moved code blocks. I extracted methods for code that has already been copy and pasted and that I would've had to copy again.

Assume you have to provision a  template with lots of role assignments for lots of principals. So far they were all applied at once. If one principal couldn't be found anymore the whole operation failed and the provisioning stopped. This is bad. But this logic is still there as step 1 - if it succeeds all is well.

I added a second step that is only triggered if step 1 fails. Then each and every principal will be checked for existance. Role assignments for non-existing principals will be removed. Then the assignment of role assignments is tried again and should now succeed. Non-existing principals are logged for the user to review:

![image](https://user-images.githubusercontent.com/3469970/89427632-c0729b00-d73b-11ea-93db-ffe66d4c9c6a.png)

(What I'm not so happy about is that I needed to pass the `WriteMessage` delegate to `SetSecurity`. Maybe there is a better solution. I need this delegate to write the warnings about non-existing principals.)