### PR TITLE
Log missing users which couldn't be added to a group and fix potential exception

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -277,19 +277,19 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 if (!ownerGroup.ServerObjectIsNull())
                 {
-                    AddUserToGroup(web, ownerGroup, siteSecurity.AdditionalOwners, scope, parser);
+                    AddUserToGroup(web, ownerGroup, siteSecurity.AdditionalOwners, scope, parser, WriteMessage);
 
                     parser.AddToken(new AssociatedGroupToken(web, AssociatedGroupToken.AssociatedGroupType.owners));                    
                 }
                 if (!memberGroup.ServerObjectIsNull())
                 {
-                    AddUserToGroup(web, memberGroup, siteSecurity.AdditionalMembers, scope, parser);
+                    AddUserToGroup(web, memberGroup, siteSecurity.AdditionalMembers, scope, parser, WriteMessage);
 
                     parser.AddToken(new AssociatedGroupToken(web, AssociatedGroupToken.AssociatedGroupType.members));                    
                 }
                 if (!visitorGroup.ServerObjectIsNull())
                 {                    
-                    AddUserToGroup(web, visitorGroup, siteSecurity.AdditionalVisitors, scope, parser);
+                    AddUserToGroup(web, visitorGroup, siteSecurity.AdditionalVisitors, scope, parser, WriteMessage);
 
                     parser.AddToken(new AssociatedGroupToken(web, AssociatedGroupToken.AssociatedGroupType.visitors));
                 }
@@ -467,7 +467,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
                     if (group != null && siteGroup.Members.Any())
                     {
-                        AddUserToGroup(web, group, siteGroup.Members, scope, parser);
+                        AddUserToGroup(web, group, siteGroup.Members, scope, parser, WriteMessage);
                     }
                 }
 
@@ -713,11 +713,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return principal;
         }
 
-        private static void AddUserToGroup(Web web, Group group, IEnumerable<User> members, PnPMonitoredScope scope, TokenParser parser)
+        private static void AddUserToGroup(Web web, Group group, IEnumerable<User> members, PnPMonitoredScope scope, TokenParser parser, ProvisioningMessagesDelegate WriteMessage)
         {
             if (members.Any())
             {
-                scope.LogDebug("Adding users to group {0}", group.IsObjectPropertyInstantiated("Title") ? group.Title : "");
+                var groupTitle = group.IsObjectPropertyInstantiated("Title") ? group.Title : "";
+                scope.LogDebug("Adding users to group {0}", groupTitle);
 
                 try
                 {
@@ -735,6 +736,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         catch (Exception ex)
                         {
                             scope.LogWarning(ex, "Failed to EnsureUser {0}", parsedUserName);
+                            WriteMessage($"User '{parsedUserName}' not found, cannot add to group {groupTitle}", ProvisioningMessageType.Warning);
                         }
                     }
 
@@ -742,7 +744,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 catch (Exception ex)
                 {
-                    scope.LogError(CoreResources.Provisioning_ObjectHandlers_SiteSecurity_Add_users_failed_for_group___0_____1_____2_, group.Title, ex.Message, ex.StackTrace);
+                    scope.LogError(CoreResources.Provisioning_ObjectHandlers_SiteSecurity_Add_users_failed_for_group___0_____1_____2_, groupTitle, ex.Message, ex.StackTrace);
                     throw;
                 }
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

Log users that couldn't be added to groups. This also makes it more consistent with other places where missing users currently often lead to provisioning being interrupted. As a PnP user I want to be informed about this. The pull request makes it look like so:

![image](https://user-images.githubusercontent.com/3469970/89460670-f24f2600-d76a-11ea-9dfa-dc47037e260e.png)


Also there is a potential error in the exception handler when accessing the group title. Fixing it while here. 