### PR TITLE
Handle update of taxonomy field specific properties seperately in UpdateField

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using System.Xml.XPath;
 using Field = OfficeDevPnP.Core.Framework.Provisioning.Model.Field;
 using SPField = Microsoft.SharePoint.Client.Field;
 
@@ -230,12 +231,15 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                         if ((existingField.TypeAsString == "TaxonomyFieldType" || existingField.TypeAsString == "TaxonomyFieldTypeMulti"))
                         {
-                            var taxField = web.Context.CastTo<TaxonomyField>(existingField);
+                            var taxField = web.Context.CastTo<TaxonomyField>(existingField); 
+                            web.Context.Load(taxField);
+                            web.Context.ExecuteQueryRetry();
+
                             if (!string.IsNullOrEmpty(existingField.DefaultValue))
                             {
                                 ValidateTaxonomyFieldDefaultValue(taxField);
                             }
-                            SetTaxonomyFieldOpenValue(taxField, originalFieldXml);
+                            UpdateTaxonomyField(taxField, existingFieldElement);
                         }
                     }
                     else
@@ -370,7 +374,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     {
                         ValidateTaxonomyFieldDefaultValue(taxField);
                     }
-                    SetTaxonomyFieldOpenValue(taxField, originalFieldXml);
                 }
             }
             else
@@ -382,16 +385,47 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
         }
 
-
-
-        private static void SetTaxonomyFieldOpenValue(TaxonomyField field, string taxonomyFieldXml)
+        private static void UpdateTaxonomyField(TaxonomyField field, XElement taxonomyFieldElement)
         {
-            bool openValue;
-            var taxonomyFieldElement = XElement.Parse(taxonomyFieldXml);
-            var openAttributeValue = taxonomyFieldElement.Attribute("Open") != null ? taxonomyFieldElement.Attribute("Open").Value : "";
-            if (bool.TryParse(openAttributeValue, out openValue))
+            bool isDirty = false;
+
+            var sspIdElement = taxonomyFieldElement.XPathSelectElement("./Customization/ArrayOfProperty/Property[Name = 'SspId']/Value");
+            if (sspIdElement != null && Guid.TryParse(sspIdElement.Value, out Guid sspIdValue) && field.SspId.Equals(sspIdValue) == false)
+            {
+                field.SspId = sspIdValue;
+                isDirty = true;
+            }
+
+            var termSetIdElement = taxonomyFieldElement.XPathSelectElement("./Customization/ArrayOfProperty/Property[Name = 'TermSetId']/Value");
+            if (termSetIdElement != null && Guid.TryParse(termSetIdElement.Value, out Guid termSetIdValue) && field.TermSetId.Equals(termSetIdValue) == false)
+            {
+                field.TermSetId = termSetIdValue;
+                isDirty = true;
+            }
+
+            var anchorIdElement = taxonomyFieldElement.XPathSelectElement("./Customization/ArrayOfProperty/Property[Name = 'AnchorId']/Value");
+            if (anchorIdElement != null & Guid.TryParse(anchorIdElement.Value, out Guid anchorIdValue) && field.AnchorId.Equals(anchorIdValue) == false)
+            {
+                field.AnchorId = anchorIdValue;
+                isDirty = true;
+            }
+
+            var openElement = taxonomyFieldElement.XPathSelectElement("./Customization/ArrayOfProperty/Property[Name = 'Open']/Value");
+            if (openElement != null && bool.TryParse(openElement.Value, out bool openValue) && field.Open.Equals(openValue) == false)
             {
                 field.Open = openValue;
+                isDirty = true;
+            }
+
+            var isPathRenderedElement = taxonomyFieldElement.XPathSelectElement("./Customization/ArrayOfProperty/Property[Name = 'IsPathRendered']/Value");
+            if (isPathRenderedElement != null && bool.TryParse(isPathRenderedElement.Value, out bool isPathRenderedValue) && field.IsPathRendered.Equals(isPathRenderedValue) == false)
+            {
+                field.IsPathRendered = isPathRenderedValue;
+                isDirty = true;
+            }
+
+            if (isDirty)
+            {
                 field.UpdateAndPushChanges(true);
                 field.Context.ExecuteQueryRetry();
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

This PR fixes an issue with update of taxonomy field specific properties like TermSetId, AnchorId, Open etc. through the Field ObjectHandler.
SharePoint doesn't seem to make changes to the properties when they are updated through the field SchemaXML, so we must handle any changes to taxonomy field properties separately.