### PR TITLE
Fix site design token parsing (and application) in tenant provisioning

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHierarchySequenceSites.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHierarchySequenceSites.cs
@@ -379,8 +379,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                         Title = tokenParser.ParseString(c.Title),
                                         Url = siteUrl
                                     };
-                                    if (Guid.TryParse(c.SiteDesign, out Guid siteDesignId))
+
+                                    Guid siteDesignId;
+                                    if (Guid.TryParse(c.SiteDesign, out siteDesignId))
                                     {
+                                        siteInfo.SiteDesignId = siteDesignId;
+                                    }
+                                    else if (Guid.TryParse(tokenParser.ParseString(c.SiteDesign), out siteDesignId))
+									{
                                         siteInfo.SiteDesignId = siteDesignId;
                                     }
                                     else

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/TenantHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/TenantHelper.cs
@@ -404,7 +404,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                             {
                                 parser.Tokens.Remove(existingToken);
                             }
-                            parser.AddToken(new SiteScriptIdToken(null, parsedTitle, existingId));
+                            parser.AddToken(new SiteDesignIdToken(null, parsedTitle, existingId));
 
                             if (siteDesign.Grants != null && siteDesign.Grants.Any())
                             {

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -166,6 +166,10 @@ namespace OfficeDevPnP.Core.Sites
             if (siteDesignId != Guid.Empty)
             {
                 payload.Add("SiteDesignId", siteDesignId);
+
+                // As per https://github.com/SharePoint/sp-dev-docs/issues/4810 the WebTemplateExtensionId property
+                // is what currently drives the application of a custom site design during the creation of a modern site.
+                payload["WebTemplateExtensionId"] = siteDesignId;
             }
 #if !SP2019
             payload.Add("HubSiteId", siteCollectionCreationInformation.HubSiteId);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #2169

#### What's in this Pull Request?

In the current release the SiteDesign attribute on the SiteCollection elements only works for OOTB Site Designs, and the token format `{SiteDesignId:Title of your site design}` does not work, as SiteDesign tokens are not getting parsed.

This PR parses the the SiteDesign token, and adds the `WebTemplateExtensionId` property to the `_api/SPSiteManager/Create` REST API call as the `SiteDesignId` property does not actually apply the Site Design during the site collection creation process (as mentioned in issue [#4810 in the sp-dev-docs repo](https://github.com/SharePoint/sp-dev-docs/issues/4810)).

In making this fix I also noticed that Site Designs (defined on the SiteCollection provisioning element) are not applied when the site collection already exists. I was not sure if that was by design, as Themes are applied on existing site collections. If Site Designs should be applied to existing site collections I am happy to create another PR to address this as well ... just let me know.