### PR TITLE
Initialize ServerRelativeUrl in NavigationExtensions.LoadFooterNavigation() before trying to use it

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/NavigationExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/NavigationExtensions.cs
@@ -783,6 +783,7 @@ namespace Microsoft.SharePoint.Client
 
             if (menuState["StartingNodeKey"] == null)
             {
+                web.EnsureProperties(w => w.ServerRelativeUrl);
                 var now = DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss:Z");
                 web.ExecutePostAsync($"/_api/navigation/SaveMenuState", $@"{{ ""menuState"":{{ ""Version"":""{now}"",""StartingNodeTitle"":""3a94b35f-030b-468e-80e3-b75ee84ae0ad"",""SPSitePrefix"":""/"",""SPWebPrefix"":""{web.ServerRelativeUrl}"",""FriendlyUrlPrefix"":"""",""SimpleUrl"":"""",""Nodes"":[]}}}}").GetAwaiter().GetResult();
                 structureString = web.ExecuteGetAsync($"/_api/navigation/MenuState?menuNodeKey='{Constants.SITEFOOTER_NODEKEY}'").GetAwaiter().GetResult();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes https://github.com/pnp/PnP-PowerShell/issues/2880

#### What's in this Pull Request?

Initialize ServerRelativeUrl property in NavigationExtensions.LoadFooterNavigation() before trying to use it.

This error occurrs on a brand new Team Site on SPO with a brand new powershell session:
![image](https://user-images.githubusercontent.com/1153754/92124843-907feb80-edfe-11ea-9e67-c8e6ee5c06a4.png)

Note that the issue happens only the first time a footer navigation node is added

Steps to reproduce the issue and test the PR:
```powershell
$link = [pscustomobject]@{
    Title = "Test link"
    Url = "https://github.com"
}
Set-PnPFooter -Enabled:$true
Add-PnPNavigationNode -Location Footer -Title $link.Title -Url $link.Url -External
```

