### PR TITLE
Allow to pass Microsoft.SharePoint.Client.AddFieldOptions when creating a field through FieldCreationInformation

### DIFF
--- a/Core/OfficeDevPnP.Core/Entities/FieldCreationInformation.cs
+++ b/Core/OfficeDevPnP.Core/Entities/FieldCreationInformation.cs
@@ -45,6 +45,10 @@ namespace OfficeDevPnP.Core.Entities
         /// Specifies filds is required to enter vlaue or not.
         /// </summary>
         public bool Required { get; set; }
+        /// <summary>
+        /// Specifies field options
+        /// </summary>
+        public AddFieldOptions FieldOptions { get; set; }
 
 #if !SP2013
         /// <summary>

--- a/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
@@ -584,7 +584,7 @@ namespace Microsoft.SharePoint.Client
             var newFieldCAML = FormatFieldXml(fieldCreationInformation);
 
             Log.Info(Constants.LOGGING_SOURCE, CoreResources.FieldAndContentTypeExtensions_CreateField01, fieldCreationInformation.InternalName, fieldCreationInformation.Id);
-            field = fields.AddFieldAsXml(newFieldCAML, fieldCreationInformation.AddToDefaultView, AddFieldOptions.AddFieldInternalNameHint);
+            field = fields.AddFieldAsXml(newFieldCAML, fieldCreationInformation.AddToDefaultView, AddFieldOptions.AddFieldInternalNameHint | fieldCreationInformation.FieldOptions);
             fields.Context.Load(field);
 
             if (executeQuery)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | partially fixes https://github.com/pnp/PnP-PowerShell/issues/2535

#### What's in this Pull Request?

Allow to pass Microsoft.SharePoint.Client.AddFieldOptions when creating a field through FieldCreationInformation. This is required by PnP PowerShell "Add-PnPField" command to implement a new option "-AddToAllContentTypes" to add the field to all list content types automatically.

#### Guidance
*You can delete this section when you are submitting the pull request.* 
* *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
* *Please target your PR to Dev branch.*