### PR TITLE
Fixed an "InvalidOperationException" when extracting multilingual resources in a multi-threaded environment

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
@@ -585,7 +585,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             if (!sourceNodes.ServerObjectIsNull.Value)
             {
                 result.NavigationNodes.AddRange(from n in sourceNodes.AsEnumerable()
-                                                select n.ToDomainModelNavigationNode(web, creationInfo.PersistMultiLanguageResources, defaultCulture));
+                                                select n.ToDomainModelNavigationNode(web, creationInfo.PersistMultiLanguageResources, defaultCulture, creationInfo));
 
                 if (creationInfo.PersistMultiLanguageResources)
                 {
@@ -604,7 +604,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         {
                             //we dont need to add to result - just extract Titles - to List as we need to 
                             var alternateLang = (from n in sourceNodes.AsEnumerable()
-                                                 select n.ToDomainModelNavigationNode(web, creationInfo.PersistMultiLanguageResources, currentCulture)).ToList();
+                                                 select n.ToDomainModelNavigationNode(web, creationInfo.PersistMultiLanguageResources, currentCulture, creationInfo)).ToList();
                         }
 
                         clientContext.PendingRequest.RequestExecutor.WebRequest.Headers["Accept-Language"] = acceptLanguage;
@@ -689,14 +689,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
     internal static class NavigationNodeExtensions
     {
-        internal static Model.NavigationNode ToDomainModelNavigationNode(this Microsoft.SharePoint.Client.NavigationNode node, Web web, bool PersistLanguage, CultureInfo currentCulture, int ParentNodeId = 0)
+        internal static Model.NavigationNode ToDomainModelNavigationNode(this Microsoft.SharePoint.Client.NavigationNode node, Web web, bool PersistLanguage, CultureInfo currentCulture, ProvisioningTemplateCreationInformation creationInfo, int ParentNodeId = 0)
         {
 
             string nodeTitle = node.Title;
 #if !SP2013
             if (PersistLanguage && !string.IsNullOrWhiteSpace(nodeTitle))
             {
-                if (UserResourceExtensions.PersistResourceValue($"NavigationNode_{ParentNodeId}_{node.Id}_Title", currentCulture.LCID, nodeTitle))
+                if (UserResourceExtensions.PersistResourceValue($"NavigationNode_{ParentNodeId}_{node.Id}_Title", currentCulture.LCID, nodeTitle, creationInfo))
                 {
                     nodeTitle = $"{{res:NavigationNode_{ParentNodeId}_{node.Id}_Title}}";
                 }
@@ -720,7 +720,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             node.Context.ExecuteQueryRetry();
 
             result.NavigationNodes.AddRange(from n in node.Children.AsEnumerable()
-                                            select n.ToDomainModelNavigationNode(web, PersistLanguage, currentCulture, node.Id));
+                                            select n.ToDomainModelNavigationNode(web, PersistLanguage, currentCulture, creationInfo, node.Id));
 
 #if !SP2013
             if (PersistLanguage)

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
@@ -334,9 +334,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         public List<String> ListsToExtract { get; set; } = new List<String>();
 
         /// <summary>
+        /// List which contains information about resource tokens used and/or created during the extraction of a template.
+        /// </summary>
+        internal List<Tuple<string, int, string>> ResourceTokens { get; } = new List<Tuple<string, int, string>>();
+
+        /// <summary>
         /// Extraction configuration coming from JSON
         /// </summary>
         internal Model.Configuration.ExtractConfiguration ExtractConfiguration { get; set; }
-
     }
 }


### PR DESCRIPTION
| Q               | A   |
| --------------- | --- |
| Bug fix?        | yes |
| New feature?    | no  |
| New sample?     | no  |
| Related issues? | -   |

#### What's in this Pull Request?

Fixed an "InvalidOperationException" when extracting multilingual resources in a multi-threaded environment. For example using a scheduler hosted in an ASP.NET application, which executes multiple extraction jobs at the same time.

Due to the previously static **ResourceTokens** list an `InvalidOperationException` with the message `Collection was modified;
enumeration operation may not execute` could occur. Now the already available instance of `ProvisioningTemplateCreationInformation` hosts the list and is used to add tokens to the list and store them within the
template.

```csharp
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
   at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
   at System.Collections.Generic.List`1.Enumerator.MoveNext()
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions.UserResourceExtensions.SaveResourceValues(ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
   at OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.ObjectLocalization.ExtractObjects(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
   at OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.SiteToTemplateConversion.GetRemoteTemplate(Web web, ProvisioningTemplateCreationInformation creationInfo)
   at Microsoft.SharePoint.Client.WebExtensions.GetProvisioningTemplate(Web web, ProvisioningTemplateCreationInformation creationInfo)
```
