### PR TITLE
Handle AddWebPartToWikiPage() being called on a non-wiki page

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/PageExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/PageExtensions.cs
@@ -256,6 +256,10 @@ namespace Microsoft.SharePoint.Client
             web.Context.ExecuteQueryRetry();
 
             string wikiField = (string)webPartPage.ListItemAllFields["WikiField"];
+            if (wikiField == null)
+            {
+                return null;
+            }
 
             var wpdNew = AddWebPart(web, webPartPage, webPart, "wpz", 0);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes https://github.com/pnp/PnP-PowerShell/issues/2921

#### What's in this Pull Request?

Currently calling AddWebPartToWikiPage() on a non-wiki page tries to run a Regex on the content of the list field "WikiField" which is null. This Pull Request adds a null check and returns null as result webpart (which is the same existing behavior if the page is not found)