### PR TITLE
Fix issue with handling of terms with comma and provided GUID

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Extensions/TaxonomyExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Extensions/TaxonomyExtensionsTests.cs
@@ -826,6 +826,37 @@ namespace Microsoft.SharePoint.Client.Tests
         }
 
         [TestMethod()]
+        public void HandleTermsWithCommanAndGuidTest()
+        {
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                var site = clientContext.Site;
+
+                var termName1 = "1stComma,Comma";
+                var term1Guid = Guid.NewGuid();
+                var termName2 = "2ndComma,Comma";
+                var term2Guid = Guid.NewGuid();
+                var termName3 = "3ndComma,Comma";
+                var term3Guid = Guid.NewGuid();
+                List<string> termLines = new List<string>();
+                string termSrc1 = _termGroupName + ";#" + _termGroupId + "|" + _termSetName1 + ";#" + _termSet1Id + "|\"" + termName1 + "\";#" + term1Guid.ToString();
+                string termSrc2 = _termGroupName + ";#" + _termGroupId + "|" + _termSetName1 + ";#" + _termSet1Id + "|\"" + termName2 + "\";#" + term2Guid.ToString() + "|\"" + termName3 + "\";#" + term3Guid.ToString();
+                termLines.Add(termSrc1);
+                termLines.Add(termSrc2);
+
+                TaxonomySession session = TaxonomySession.GetTaxonomySession(clientContext);
+                var termStore = session.GetDefaultSiteCollectionTermStore();
+                site.ImportTerms(termLines.ToArray(), 1033, termStore, "|");
+
+                var terms = site.ExportTermSet(_termSet1Id, true);
+                string termDest1 = terms.SingleOrDefault(t => t.Contains(termName1));
+                string termDest2 = terms.SingleOrDefault(t => t.Contains(termName3));
+                Assert.AreEqual(termSrc1, termDest1);
+                Assert.AreEqual(termSrc2, termDest2);
+            }
+        }
+
+        [TestMethod()]
         public void HandleTermsWithQuotesTest()
         {
             using (var clientContext = TestCommon.CreateClientContext())

--- a/Core/OfficeDevPnP.Core/Extensions/TaxonomyExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/TaxonomyExtensions.cs
@@ -1201,7 +1201,7 @@ namespace Microsoft.SharePoint.Client
                         || (!char.IsWhiteSpace(lineChars[charIndex]) && lineChars[charIndex] != '"'))
                     {
                         if (flagInsideQuotes && lineChars[charIndex] == '"'
-                            && (charIndex + 1 >= line.Length || lineChars[charIndex + 1] == ','))
+                            && (charIndex + 1 >= line.Length || lineChars[charIndex + 1] == ',' || lineChars[charIndex + 1] == '|'))
                         {
                             // End of quotes (and either end of line or next char is comma)
                             flagInsideQuotes = false;
@@ -1463,13 +1463,18 @@ namespace Microsoft.SharePoint.Client
         public static string NormalizeName(string name)
         {
             if (name == null) return (string)null;
-            name = TrimSpacesRegex.Replace(name, " ").Replace('&', '＆');
 
-            if (!name.Contains(",") || !name.StartsWith("\"") || !name.EndsWith("\""))
+            var hasGuid = name.IndexOf("|") > -1;
+
+            var nameToNormalize = hasGuid ? name.Split('|')[0] : name;
+
+            nameToNormalize = TrimSpacesRegex.Replace(nameToNormalize, " ").Replace('&', '＆');
+
+            if (!nameToNormalize.Contains(",") || !nameToNormalize.StartsWith("\"") || !nameToNormalize.EndsWith("\""))
             {
-                name = name.Replace('"', '＂');
+                nameToNormalize = nameToNormalize.Replace('"', '＂');
             }
-            return name;
+            return hasGuid ? string.Format("{0}|{1}", nameToNormalize, name.Split('|')[1]) : nameToNormalize;
         }
 
         /// <summary>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1955

#### What's in this Pull Request?

Fixes an issue where importing terms which include commas, while also providing a GUID for the terms, would create the wrong hierarchy in the termstore.

A import like this:
> Group;#XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX|Set;#XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX|"TermX,TermY";#ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ

would create a structure like this
> Group > Set > "TermX > TermY"
> TermY" has the GUID ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ

instead of
> Group > Set > TermX,TermY
> TermX,TermY has the GUID ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ
