### PR TITLE
Fix: Removed unnecessary compiler directive and using that prevented build of PnPCore.sln

### DIFF
--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -21,7 +21,6 @@ using System.Net.Http;
 using Newtonsoft.Json.Linq;
 using OfficeDevPnP.Core.Utilities.Context;
 using System.Web;
-using System.Windows.Threading;
 
 namespace OfficeDevPnP.Core
 {
@@ -1168,7 +1167,6 @@ namespace OfficeDevPnP.Core
             return clientContext;
         }
 
-#if !NETSTANDARD2_0
         /// <summary>
         /// Returns a SharePoint ClientContext using Azure Active Directory App Only Authentication. This requires that you have a certificated created, and updated the key credentials key in the application manifest in the azure AD accordingly.
         /// </summary>
@@ -1188,8 +1186,6 @@ namespace OfficeDevPnP.Core
             string authority = string.Format(CultureInfo.InvariantCulture, "{0}/{1}/", GetAzureADLoginEndPoint(environment), tenant);
 
             var authContext = new AuthenticationContext(authority);
-
-            //var clientAssertionCertificate = new ClientAssertionCertificate(clientId, certificate);
 
             var host = new Uri(siteUrl);
 
@@ -1216,7 +1212,6 @@ namespace OfficeDevPnP.Core
 
             return clientContext;
         }
-#endif
 
 
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

Removed unnecessary compiler directive and using that prevented build of PnPCore.sln. The compiler directive excluded a method used in another part of the solution which was not excluded and caused the build of PnPCore.sln for .NET Standard 2.0 to fail. The previously excluded method has been manually tested from .NET Core 3.1 without any issues so there should be no need to exclude it.
