### PR TITLE
Adjust tenant admin check to support an App Only AAD connection

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/TenantExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/TenantExtensions.cs
@@ -1027,14 +1027,20 @@ namespace Microsoft.SharePoint.Client
 #if !ONPREMISES
         public static bool IsCurrentUserTenantAdmin(ClientContext clientContext)
         {
+            // In order to support an App Only AAD connection that has Sites.FullControl.All permission
+            // we need to check via the SPO approach first as the Microsoft Graph approach currently
+            // assumes a user is connected and therefore does not work for an App Only AAD connection.
+            if (IsCurrentUserTenantAdminViaSPO(clientContext))
+            {
+                return true;
+			}
+
             if (PnPProvisioningContext.Current != null)
             {
                 return IsCurrentUserTenantAdminViaGraph();
             }
-            else
-            {
-                return IsCurrentUserTenantAdminViaSPO(clientContext);
-            }
+
+            return false;
         }
 
         private static bool IsCurrentUserTenantAdminViaGraph()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | none that I'm aware of

#### What's in this Pull Request?

When using an App Only AAD connection that has a PnPProvisioningContext delegate setup (in PnP PowerShell this came up for me with ApplyTenantTemplate), IsCurrentUserTenantAdmin would call https://graph.microsoft.com/v1.0/me/memberOf?$select=id,displayName in order to see if the current user is in the _Company Administrator_ role; this approach does not work for an App Only AAD connection. If the AAD App doesn't have Graph permission to read users (which is a valid scenario for all of the provisioning we have been doing to date) you get the following error when calling that endpoint

```
{
  "error": {
    "code": "Authorization_RequestDenied",
    "message": "Insufficient privileges to complete the operation.",
    "innerError": {
      "date": "2020-10-03T17:52:28",
      "request-id": "9e5fba82-4cb1-4011-bac6-3ab0573a0523",
      "client-request-id": "9e5fba82-4cb1-4011-bac6-3ab0573a0523"
    }
  }
}
```
If the AAD App has the MSGraph.User.Read.All you get the following error since I believe this endpoint is intended for a connected user (not an app only context)

```
{
  "error": {
    "code": "Request_ResourceNotFound",
    "message": "Resource 'ac9cd37e-a832-4d17-a045-c888d06ad217' does not exist or one of its queried reference-property objects are not present.",
    "innerError": {
      "date": "2020-10-03T17:50:34",
      "request-id": "64786a8f-7701-4d25-84eb-4f7b77a8554f",
      "client-request-id": "64786a8f-7701-4d25-84eb-4f7b77a8554f"
    }
  }
}
```

As a simple fix, I adjusted the logic to check if the current connection has admin privileges via the SPO approach first; if that check returns false we then check via the Microsoft Graph. A more comprehensive approach would be to identify the type of connection (user or app only) and call a different endpoint to retrieve the app's permissions to see if it has SPO.Sites.FullControl.All; but I'll leave that for another day as the simple approach I've included in this PR does the trick for now.

**NOTE:** if you want to test this with PnP PowerShell's ApplyTenantTemplate cmdlet you'll need to apply the [Pull Request](https://github.com/pnp/PnP-PowerShell/pull/2944) I recently submitted, as App Only AAD connections broke due to some auth changes in the August release and this PR addresses the issue for the ApplyTenantTemplate cmdlet.