### PR TITLE
Reapply PR #2596 which addresses Issue #2595

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Resolvers/V202002/SharingSettingsFromSchemaToModel.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Resolvers/V202002/SharingSettingsFromSchemaToModel.cs
@@ -39,7 +39,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.Resolvers.V2020
                 }
             }
 
-            return (result);
+            return (null);
         }
     }
 }


### PR DESCRIPTION
This fix from @SteveClements in March was overridden in May, so I am reapplying it.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #2595 

#### What's in this Pull Request?

This is from the original PR #2596 that was merged but later overridden:

As per item #2595 a simple change to `OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.Resolvers.V202002.SharingSettingsFromSchemaToModel` to return `null` when `SharingSettings` are not used in the template XML.

Currently it will return a default value which is `Disabled`


