### PR TITLE
Fix for sublinks not provisioned in Footer

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
@@ -347,11 +347,20 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                         foreach (var footerLink in template.Footer.FooterLinks)
                         {
-                            menuNode.Children.Add(new NavigationNodeCreationInformation()
+                            var newParentNode = menuNode.Children.Add(new NavigationNodeCreationInformation()
                             {
                                 Url = parser.ParseString(footerLink.Url),
                                 Title = parser.ParseString(footerLink.DisplayName)
                             });
+
+                            foreach (var childFooterLink in footerLink.FooterLinks)
+                            {
+                                newParentNode.Children.Add(new NavigationNodeCreationInformation()
+                                {
+                                    Url = parser.ParseString(childFooterLink.Url),
+                                    Title = parser.ParseString(childFooterLink.DisplayName)
+                                });
+                            }
                         }
                         if (web.Context.PendingRequestCount() > 0)
                         {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #2792

#### What's in this Pull Request?

Fixes #2792 by adding children nodes of FooterLink element. Extended modern footer contains 2 levels of navigation nodes. Simple modern footer contains 1 level, thus bug occurred when 2 levels extended footer was introduced.