### PR TITLE
Fix Layout dedection for TwoColumnRightVerticalSection and TwoColumnLeftVerticalSection

### DIFF
--- a/Core/OfficeDevPnP.Core/Pages/ClientSidePage.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSidePage.cs
@@ -2224,15 +2224,15 @@ namespace OfficeDevPnP.Core.Pages
                     }
                     else if (section.Columns.Count == 3)
                     {
-                        if (section.Columns[1].ColumnFactor == 6)
+                        if (section.Columns[0].ColumnFactor == 6)
                         {
                             section.Type = CanvasSectionTemplate.TwoColumnVerticalSection;
                         }
-                        else if (section.Columns[1].ColumnFactor == 4)
+                        else if (section.Columns[0].ColumnFactor == 4)
                         {
                             section.Type = CanvasSectionTemplate.TwoColumnRightVerticalSection;
                         }
-                        else if (section.Columns[1].ColumnFactor == 8)
+                        else if (section.Columns[0].ColumnFactor == 8)
                         {
                             section.Type = CanvasSectionTemplate.TwoColumnLeftVerticalSection;
                         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
The TwoColumnRightVerticalSection and TwoColumnLeftVerticalSection where wrong because the compare for ColumnFactor was done with Col 1 instead of Col 0. As a result we would get 1/3 and 2/3 instead of 2/3 and 1/3 Layout with Vertical Section.