### PR TITLE
All COntent of the Field needs proper HtmlEncode not only &

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -859,7 +859,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 if (customFormatterElement != null)
                 {
                     var customFormatter = customFormatterElement.Value;
-                    customFormatter = customFormatter.Replace("&", "&amp;");
+                    customFormatter = System.Net.WebUtility.HtmlEncode(customFormatter);
                     if (createdView.CustomFormatter != customFormatter)
                     {
                         createdView.CustomFormatter = customFormatter;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
The List View Formatter Field fails during provisioning since in more complex Formatters like the new List-App provides multiple char need to be encoded in order to set the value. The Fix does a full html-encoding of the Formatter string.