### PR TITLE
Fix Folder Compare - not match if Foldername contains +

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
@@ -1052,7 +1052,8 @@ namespace Microsoft.SharePoint.Client
                 Folder nextFolder = null;
                 foreach (Folder existingFolder in folderCollection)
                 {
-                    if (string.Equals(existingFolder.Name, System.Net.WebUtility.UrlDecode(folderName), StringComparison.InvariantCultureIgnoreCase))
+                    //System.Net.WebUtility.UrlDecode removes + from folderName which leads to invalid compare if folderName was not UrlEncoded 
+                    if (string.Equals(existingFolder.Name, System.Net.WebUtility.UrlDecode(folderName), StringComparison.InvariantCultureIgnoreCase)|| string.Equals(existingFolder.Name, folderName, StringComparison.InvariantCultureIgnoreCase))
                     {
                         nextFolder = existingFolder;
                         break;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Ensure Folder will fail with Foldernames containg + in the Name like "This + That" since UrlDecode in compare does remove the + char from the string and therefore will not detect the existing "This + That" folder correctly.

I could not really figure out from history why UrlDecode is needed after all - so i just added a direct name compare which was good enough for my cases.